### PR TITLE
Reduce code complexity in flagged functions

### DIFF
--- a/scripts/analyze_boot_process.py
+++ b/scripts/analyze_boot_process.py
@@ -616,7 +616,88 @@ def analyze_boot_config(dts_file: Path, analysis: BootProcessAnalysis) -> None:
         pass
 
 
-def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:  # noqa: PLR0912, PLR0915
+def _write_hardware_table(f: Any, hardware_properties: list[HardwareProperty]) -> None:
+    """Write hardware platform table to markdown."""
+    f.write("## Hardware Platform\n")
+    f.write("\n")
+    f.write("| Property | Value | Source |\n")
+    f.write("|----------|-------|--------|\n")
+    for prop in hardware_properties:
+        f.write(f"| {prop.property} | {prop.value} | {prop.source} |\n")
+    f.write("\n")
+
+
+def _write_partitions_table(f: Any, partitions: list[Partition]) -> None:
+    """Write partition layout table to markdown."""
+    f.write("## Partition Layout\n")
+    f.write("\n")
+    f.write("Derived from firmware offsets in `binwalk-offsets.sh`:\n")
+    f.write("\n")
+    f.write("| Region | Offset | Size | Type | Content |\n")
+    f.write("|--------|--------|------|------|---------||\n")
+    for partition in partitions:
+        f.write(
+            f"| {partition.region} | `{partition.offset}` | ~{partition.size_mb} MB | "
+            f"{partition.type} | {partition.content} |\n"
+        )
+    f.write("\n")
+    f.write("*Note: Sizes calculated from offset differences. ")
+    f.write("Actual partition table may differ.*\n")
+    f.write("\n")
+
+
+def _write_fit_section(f: Any, title: str, fit_info: str | None) -> None:
+    """Write a FIT image section to markdown."""
+    if fit_info:
+        f.write(f"### {title}\n")
+        f.write("\n")
+        f.write("```\n")
+        if "configurations" in fit_info:
+            lines = fit_info.split("\n")
+            in_config = False
+            line_count = 0
+            for line in lines:
+                if "configurations" in line:
+                    in_config = True
+                if in_config:
+                    f.write(line + "\n")
+                    line_count += 1
+                    if line_count >= FIT_INFO_LINE_LIMIT:
+                        break
+        else:
+            f.write("Could not parse\n")
+        f.write("```\n")
+    else:
+        f.write(f"*{title} DTS not available*\n")
+    f.write("\n")
+
+
+def _write_boot_config(
+    f: Any, kernel_cmdline: str | None, console_configs: list[ConsoleConfig]
+) -> None:
+    """Write boot configuration section to markdown."""
+    f.write("## Boot Configuration\n")
+    f.write("\n")
+
+    if kernel_cmdline:
+        f.write("### Kernel Command Line\n")
+        f.write("\n")
+        f.write("```\n")
+        f.write(kernel_cmdline)
+        f.write("\n```\n")
+        f.write("\n")
+
+    if console_configs:
+        f.write("### Console Configuration\n")
+        f.write("\n")
+        f.write("| Parameter | Value | Source |\n")
+        f.write("|-----------|-------|--------|\n")
+        for config in console_configs:
+            f.write(f"| {config.parameter} | {config.value} | {config.source} |\n")
+        f.write("\n")
+
+
+def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:
     """Generate markdown report for backward compatibility."""
     timestamp = datetime.now(UTC).isoformat()
 
@@ -633,13 +714,7 @@ def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:
 
         # Hardware Platform
         if analysis.hardware_properties:
-            f.write("## Hardware Platform\n")
-            f.write("\n")
-            f.write("| Property | Value | Source |\n")
-            f.write("|----------|-------|--------|\n")
-            for prop in analysis.hardware_properties:
-                f.write(f"| {prop.property} | {prop.value} | {prop.source} |\n")
-            f.write("\n")
+            _write_hardware_table(f, analysis.hardware_properties)
 
         # Boot Chain
         f.write("## Boot Chain\n")
@@ -669,73 +744,14 @@ def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:
 
         # Partition Layout
         if analysis.partitions:
-            f.write("## Partition Layout\n")
-            f.write("\n")
-            f.write("Derived from firmware offsets in `binwalk-offsets.sh`:\n")
-            f.write("\n")
-            f.write("| Region | Offset | Size | Type | Content |\n")
-            f.write("|--------|--------|------|------|---------||\n")
-            for partition in analysis.partitions:
-                f.write(
-                    f"| {partition.region} | `{partition.offset}` | ~{partition.size_mb} MB | "
-                    f"{partition.type} | {partition.content} |\n"
-                )
-            f.write("\n")
-            f.write("*Note: Sizes calculated from offset differences. ")
-            f.write("Actual partition table may differ.*\n")
-            f.write("\n")
+            _write_partitions_table(f, analysis.partitions)
 
         # FIT Image Structure
         f.write("## FIT Image Structure\n")
         f.write("\n")
 
-        if analysis.bootloader_fit_info:
-            f.write("### Bootloader FIT\n")
-            f.write("\n")
-            f.write("```\n")
-            # Extract configurations section
-            if "configurations" in analysis.bootloader_fit_info:
-                lines = analysis.bootloader_fit_info.split("\n")
-                in_config = False
-                line_count = 0
-                for line in lines:
-                    if "configurations" in line:
-                        in_config = True
-                    if in_config:
-                        f.write(line + "\n")
-                        line_count += 1
-                        if line_count >= FIT_INFO_LINE_LIMIT:
-                            break
-            else:
-                f.write("Could not parse\n")
-            f.write("```\n")
-        else:
-            f.write("*Bootloader FIT DTS not available*\n")
-        f.write("\n")
-
-        if analysis.kernel_fit_info:
-            f.write("### Kernel FIT\n")
-            f.write("\n")
-            f.write("```\n")
-            # Extract configurations section
-            if "configurations" in analysis.kernel_fit_info:
-                lines = analysis.kernel_fit_info.split("\n")
-                in_config = False
-                line_count = 0
-                for line in lines:
-                    if "configurations" in line:
-                        in_config = True
-                    if in_config:
-                        f.write(line + "\n")
-                        line_count += 1
-                        if line_count >= FIT_INFO_LINE_LIMIT:
-                            break
-            else:
-                f.write("Could not parse\n")
-            f.write("```\n")
-        else:
-            f.write("*Kernel FIT DTS not available*\n")
-        f.write("\n")
+        _write_fit_section(f, "Bootloader FIT", analysis.bootloader_fit_info)
+        _write_fit_section(f, "Kernel FIT", analysis.kernel_fit_info)
 
         # A/B Partition Scheme
         f.write("## A/B Partition Scheme\n")
@@ -749,25 +765,7 @@ def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:
         f.write("\n")
 
         # Boot Configuration
-        f.write("## Boot Configuration\n")
-        f.write("\n")
-
-        if analysis.kernel_cmdline:
-            f.write("### Kernel Command Line\n")
-            f.write("\n")
-            f.write("```\n")
-            f.write(analysis.kernel_cmdline)
-            f.write("\n```\n")
-            f.write("\n")
-
-        if analysis.console_configs:
-            f.write("### Console Configuration\n")
-            f.write("\n")
-            f.write("| Parameter | Value | Source |\n")
-            f.write("|-----------|-------|--------|\n")
-            for config in analysis.console_configs:
-                f.write(f"| {config.parameter} | {config.value} | {config.source} |\n")
-            f.write("\n")
+        _write_boot_config(f, analysis.kernel_cmdline, analysis.console_configs)
 
     success("Wrote boot-process.md")
 

--- a/scripts/analyze_network_services.py
+++ b/scripts/analyze_network_services.py
@@ -368,7 +368,58 @@ def find_firewall_rules(rootfs: Path) -> list[str]:
     return list(dict.fromkeys(rules))[:5]
 
 
-def analyze_firmware(  # noqa: PLR0915
+def _scan_network_services(analysis: NetworkServicesAnalysis, rootfs: Path) -> None:
+    """Scan rootfs for network services and populate analysis fields."""
+    analysis.init_scripts = find_init_scripts(rootfs)
+    if analysis.init_scripts:
+        analysis.add_metadata(
+            "init_scripts",
+            "filesystem",
+            "find /etc/init.d -maxdepth 1 -type f",
+        )
+
+    analysis.systemd_services = find_systemd_services(rootfs)
+    if analysis.systemd_services:
+        analysis.add_metadata(
+            "systemd_services",
+            "filesystem",
+            "find rootfs -name '*.service' -type f",
+        )
+
+    analysis.web_servers = find_web_servers(rootfs)
+    if analysis.web_servers:
+        analysis.add_metadata(
+            "web_servers",
+            "filesystem",
+            "find rootfs for nginx, lighttpd, httpd, apache2, uvicorn, gunicorn",
+        )
+
+    analysis.web_frameworks = find_web_frameworks(rootfs)
+    if analysis.web_frameworks:
+        analysis.add_metadata(
+            "web_frameworks",
+            "filesystem",
+            "find rootfs -path '*/site-packages/aiohttp*' or uvicorn*",
+        )
+
+    analysis.ssh_server = find_ssh_server(rootfs)
+    if analysis.ssh_server:
+        analysis.add_metadata(
+            "ssh_server",
+            "filesystem",
+            "find rootfs for sshd or dropbear",
+        )
+
+    analysis.network_services = find_network_services(rootfs)
+    if analysis.network_services:
+        analysis.add_metadata(
+            "network_services",
+            "filesystem",
+            "find rootfs for dnsmasq, hostapd, mosquitto, telnetd, etc.",
+        )
+
+
+def analyze_firmware(
     firmware_path: str, rootfs: Path
 ) -> NetworkServicesAnalysis:
     """Analyze firmware for network services and attack surface.
@@ -395,60 +446,7 @@ def analyze_firmware(  # noqa: PLR0915
 
     # Scan for network services
     section("Scanning for network services")
-
-    # Find init scripts
-    analysis.init_scripts = find_init_scripts(rootfs)
-    if analysis.init_scripts:
-        analysis.add_metadata(
-            "init_scripts",
-            "filesystem",
-            "find /etc/init.d -maxdepth 1 -type f",
-        )
-
-    # Find systemd services
-    analysis.systemd_services = find_systemd_services(rootfs)
-    if analysis.systemd_services:
-        analysis.add_metadata(
-            "systemd_services",
-            "filesystem",
-            "find rootfs -name '*.service' -type f",
-        )
-
-    # Find web servers
-    analysis.web_servers = find_web_servers(rootfs)
-    if analysis.web_servers:
-        analysis.add_metadata(
-            "web_servers",
-            "filesystem",
-            "find rootfs for nginx, lighttpd, httpd, apache2, uvicorn, gunicorn",
-        )
-
-    # Find web frameworks
-    analysis.web_frameworks = find_web_frameworks(rootfs)
-    if analysis.web_frameworks:
-        analysis.add_metadata(
-            "web_frameworks",
-            "filesystem",
-            "find rootfs -path '*/site-packages/aiohttp*' or uvicorn*",
-        )
-
-    # Find SSH server
-    analysis.ssh_server = find_ssh_server(rootfs)
-    if analysis.ssh_server:
-        analysis.add_metadata(
-            "ssh_server",
-            "filesystem",
-            "find rootfs for sshd or dropbear",
-        )
-
-    # Find other network services
-    analysis.network_services = find_network_services(rootfs)
-    if analysis.network_services:
-        analysis.add_metadata(
-            "network_services",
-            "filesystem",
-            "find rootfs for dnsmasq, hostapd, mosquitto, telnetd, etc.",
-        )
+    _scan_network_services(analysis, rootfs)
 
     # Security analysis
     section("Security analysis")

--- a/scripts/analyze_network_services.py
+++ b/scripts/analyze_network_services.py
@@ -419,9 +419,7 @@ def _scan_network_services(analysis: NetworkServicesAnalysis, rootfs: Path) -> N
         )
 
 
-def analyze_firmware(
-    firmware_path: str, rootfs: Path
-) -> NetworkServicesAnalysis:
+def analyze_firmware(firmware_path: str, rootfs: Path) -> NetworkServicesAnalysis:
     """Analyze firmware for network services and attack surface.
 
     Args:

--- a/scripts/analyze_secure_boot.py
+++ b/scripts/analyze_secure_boot.py
@@ -222,7 +222,92 @@ def extract_device_tree_node(
     return None
 
 
-def analyze_secure_boot(  # noqa: PLR0912, PLR0915
+def _analyze_uboot_strings(
+    analysis: SecureBootAnalysis, firmware: Path, offsets: dict[str, str | int]
+) -> None:
+    """Extract and analyze U-Boot verification strings from gzip-compressed data."""
+    uboot_offset_dec = offsets.get("UBOOT_GZ_OFFSET_DEC")
+    if not isinstance(uboot_offset_dec, int):
+        return
+
+    uboot_data = extract_gzip_at_offset(firmware, uboot_offset_dec, 500000, use_dd=False)
+    uboot_strings = extract_strings(uboot_data) if uboot_data else []
+
+    verification_patterns = [
+        r"verified",
+        r"signature",
+        r"secure.?boot",
+        r"FIT.*sign",
+        r"required",
+        r"rsa.*verify",
+    ]
+    analysis.uboot_verification_strings = filter_strings(
+        uboot_strings, regex_patterns=verification_patterns
+    )[:30]
+
+    if analysis.uboot_verification_strings:
+        analysis.add_metadata(
+            "uboot_verification_strings",
+            "strings",
+            (
+                "gunzip U-Boot | strings | grep -E "
+                "'verified|signature|secure.?boot|FIT.*sign|required|rsa.*verify'"
+            ),
+        )
+
+    key_patterns = [
+        r"FIT:.*signed",
+        r"Verified-boot:",
+        r"Can't read verified-boot",
+        r"CONFIG_FIT_SIGNATURE",
+    ]
+    analysis.uboot_key_findings = filter_strings(uboot_strings, regex_patterns=key_patterns)
+
+    if analysis.uboot_key_findings:
+        analysis.add_metadata(
+            "uboot_key_findings",
+            "strings",
+            (
+                "gunzip U-Boot | strings | grep -E "
+                "'FIT:.*signed|Verified-boot:|Can't read verified-boot|CONFIG_FIT_SIGNATURE'"
+            ),
+        )
+
+
+def _analyze_optee_strings(
+    analysis: SecureBootAnalysis, firmware: Path, offsets: dict[str, str | int]
+) -> None:
+    """Extract and analyze OP-TEE secure boot strings from gzip-compressed data."""
+    optee_offset_dec = offsets.get("OPTEE_GZ_OFFSET_DEC")
+    if not isinstance(optee_offset_dec, int):
+        return
+
+    optee_data = extract_gzip_at_offset(firmware, optee_offset_dec, 300000, use_dd=False)
+    optee_strings = extract_strings(optee_data) if optee_data else []
+
+    secure_boot_patterns = [
+        r"secure.?boot",
+        r"otp.*key",
+        r"set.*flag",
+        r"key.*index",
+        r"enable.*flag",
+    ]
+    analysis.optee_secure_boot_strings = filter_strings(
+        optee_strings, regex_patterns=secure_boot_patterns
+    )[:30]
+
+    if analysis.optee_secure_boot_strings:
+        analysis.add_metadata(
+            "optee_secure_boot_strings",
+            "strings",
+            (
+                "gunzip OP-TEE | strings | grep -E "
+                "'secure.?boot|otp.*key|set.*flag|key.*index|enable.*flag'"
+            ),
+        )
+
+
+def analyze_secure_boot(
     firmware_path: str, offsets: dict[str, str | int], work_dir: Path
 ) -> SecureBootAnalysis:
     """Analyze secure boot configuration in firmware.
@@ -237,7 +322,6 @@ def analyze_secure_boot(  # noqa: PLR0912, PLR0915
     """
     firmware = Path(firmware_path)
 
-    # Create analysis object
     analysis = SecureBootAnalysis(
         firmware_file=firmware.name,
         firmware_size=firmware.stat().st_size,
@@ -306,85 +390,11 @@ def analyze_secure_boot(  # noqa: PLR0912, PLR0915
 
     # Analyze U-Boot strings
     section("Analyzing U-Boot verification strings")
-
-    uboot_offset_dec = offsets.get("UBOOT_GZ_OFFSET_DEC")
-    if isinstance(uboot_offset_dec, int):
-        # Extract and decompress U-Boot gzip data
-        uboot_data = extract_gzip_at_offset(firmware, uboot_offset_dec, 500000, use_dd=False)
-        uboot_strings = extract_strings(uboot_data) if uboot_data else []
-
-        # Filter for verification-related strings
-        verification_patterns = [
-            r"verified",
-            r"signature",
-            r"secure.?boot",
-            r"FIT.*sign",
-            r"required",
-            r"rsa.*verify",
-        ]
-        analysis.uboot_verification_strings = filter_strings(
-            uboot_strings, regex_patterns=verification_patterns
-        )[:30]
-
-        if analysis.uboot_verification_strings:
-            analysis.add_metadata(
-                "uboot_verification_strings",
-                "strings",
-                (
-                    "gunzip U-Boot | strings | grep -E "
-                    "'verified|signature|secure.?boot|FIT.*sign|required|rsa.*verify'"
-                ),
-            )
-
-        # Key findings
-        key_patterns = [
-            r"FIT:.*signed",
-            r"Verified-boot:",
-            r"Can't read verified-boot",
-            r"CONFIG_FIT_SIGNATURE",
-        ]
-        analysis.uboot_key_findings = filter_strings(uboot_strings, regex_patterns=key_patterns)
-
-        if analysis.uboot_key_findings:
-            analysis.add_metadata(
-                "uboot_key_findings",
-                "strings",
-                (
-                    "gunzip U-Boot | strings | grep -E "
-                    "'FIT:.*signed|Verified-boot:|Can't read verified-boot|CONFIG_FIT_SIGNATURE'"
-                ),
-            )
+    _analyze_uboot_strings(analysis, firmware, offsets)
 
     # Analyze OP-TEE strings
     section("Analyzing OP-TEE secure boot strings")
-
-    optee_offset_dec = offsets.get("OPTEE_GZ_OFFSET_DEC")
-    if isinstance(optee_offset_dec, int):
-        # Extract and decompress OP-TEE gzip data
-        optee_data = extract_gzip_at_offset(firmware, optee_offset_dec, 300000, use_dd=False)
-        optee_strings = extract_strings(optee_data) if optee_data else []
-
-        # Filter for secure boot related strings
-        secure_boot_patterns = [
-            r"secure.?boot",
-            r"otp.*key",
-            r"set.*flag",
-            r"key.*index",
-            r"enable.*flag",
-        ]
-        analysis.optee_secure_boot_strings = filter_strings(
-            optee_strings, regex_patterns=secure_boot_patterns
-        )[:30]
-
-        if analysis.optee_secure_boot_strings:
-            analysis.add_metadata(
-                "optee_secure_boot_strings",
-                "strings",
-                (
-                    "gunzip OP-TEE | strings | grep -E "
-                    "'secure.?boot|otp.*key|set.*flag|key.*index|enable.*flag'"
-                ),
-            )
+    _analyze_optee_strings(analysis, firmware, offsets)
 
     # Analyze device tree
     section("Analyzing device tree OTP/crypto nodes")

--- a/scripts/analyze_uboot.py
+++ b/scripts/analyze_uboot.py
@@ -178,9 +178,7 @@ def _parse_uboot_strings(analysis: UBootAnalysis, uboot_strings: list[str]) -> N
             "strings matching '^boot(cmd|args|delay)='",
         )
 
-    env_vars = [
-        s for s in uboot_strings if re.match(r"^[a-z_]+=", s) and not s.startswith("boot")
-    ]
+    env_vars = [s for s in uboot_strings if re.match(r"^[a-z_]+=", s) and not s.startswith("boot")]
     if env_vars:
         analysis.environment_variables = env_vars[:20]
         analysis.add_metadata(

--- a/scripts/analyze_uboot.py
+++ b/scripts/analyze_uboot.py
@@ -24,6 +24,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from lib.analysis_base import AnalysisBase
 from lib.base_script import AnalysisScript
@@ -96,33 +97,17 @@ def run_strings(firmware: Path) -> str:
 # extract_gzip_at_offset and extract_strings_from_data are now imported from lib.extraction
 
 
-def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:  # noqa: PLR0912, PLR0915
-    """Analyze U-Boot bootloader in firmware and return structured results."""
-    firmware = Path(firmware_path)
+def _extract_uboot_version(
+    analysis: UBootAnalysis,
+    firmware: Path,
+    firmware_strings: str,
+    offset_manager: OffsetManager,
+) -> list[str]:
+    """Search for U-Boot version using direct strings and gzip extraction.
 
-    # Create analysis object
-    analysis = UBootAnalysis(
-        firmware_file=firmware.name,
-        firmware_size=firmware.stat().st_size,
-    )
-    analysis.add_metadata("firmware_file", "filesystem", "Path(firmware).name")
-    analysis.add_metadata("firmware_size", "filesystem", "Path(firmware).stat().st_size")
-
-    # Load offsets from binwalk analysis
-    offset_manager = OffsetManager(output_dir)
-    try:
-        offset_manager.load_from_shell_script()
-    except FileNotFoundError:
-        warn("Firmware offsets not found: binwalk-offsets.sh")
-        warn("Run analyze_binwalk.py first to generate offset artifacts")
-
-    section("Extracting U-Boot version")
-
+    Returns the list of U-Boot strings from gzip extraction (empty if not used).
+    """
     # Method 1: Search firmware directly for U-Boot strings
-    uboot_strings = []
-    firmware_strings = run_strings(firmware)
-
-    # Look for U-Boot version in firmware strings
     for line in firmware_strings.splitlines():
         if re.search(r"U-Boot [0-9]+\.[0-9]+", line):
             analysis.version = line.strip()
@@ -136,19 +121,18 @@ def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:  # noq
             break
 
     # Method 2: Try extracting from gzip-compressed U-Boot binary
+    uboot_strings: list[str] = []
     offset_dec = offset_manager.get_dec("UBOOT_GZ")
     if not analysis.version and offset_dec is not None:
         offset_hex = offset_manager.get_hex("UBOOT_GZ") or hex(offset_dec)
 
         info(f"Attempting to extract U-Boot from gzip at offset {offset_hex}")
 
-        # Extract and decompress
         decompressed_data = extract_gzip_at_offset(firmware, offset_dec, UBOOT_EXTRACT_SIZE)
 
         if decompressed_data:
             uboot_strings = extract_strings(decompressed_data)
 
-            # Find version string
             for string in uboot_strings:
                 if re.search(r"U-Boot [0-9]+\.[0-9]+", string):
                     analysis.version = string.strip()
@@ -159,7 +143,6 @@ def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:  # noq
                     )
                     break
 
-            # Find build date
             for string in uboot_strings:
                 if re.match(r"^\([A-Za-z]+ [A-Za-z]+ [0-9]+", string):
                     analysis.build_date = string.strip()
@@ -179,96 +162,118 @@ def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:  # noq
             )
             analysis.add_metadata("extraction_offset", "binwalk", "UBOOT_GZ_OFFSET")
 
-    # Parse detailed information from U-Boot strings
+    return uboot_strings
+
+
+def _parse_uboot_strings(analysis: UBootAnalysis, uboot_strings: list[str]) -> None:
+    """Parse detailed configuration from U-Boot strings."""
+    section("Extracting U-Boot configuration")
+
+    boot_commands = [s for s in uboot_strings if re.match(r"^boot(cmd|args|delay)=", s)]
+    if boot_commands:
+        analysis.boot_commands = boot_commands[:10]
+        analysis.add_metadata(
+            "boot_commands",
+            "gzip_extraction",
+            "strings matching '^boot(cmd|args|delay)='",
+        )
+
+    env_vars = [
+        s for s in uboot_strings if re.match(r"^[a-z_]+=", s) and not s.startswith("boot")
+    ]
+    if env_vars:
+        analysis.environment_variables = env_vars[:20]
+        analysis.add_metadata(
+            "environment_variables",
+            "gzip_extraction",
+            "strings matching '^[a-z_]+=' excluding boot commands",
+        )
+
+    command_pattern = r"^(mmc|usb|tftp|nfs|dhcp|ping|md|mw|sf|nand)"
+    commands = [s for s in uboot_strings if re.match(command_pattern, s)]
+    if commands:
+        analysis.supported_commands = sorted(set(commands))[:20]
+        analysis.add_metadata(
+            "supported_commands",
+            "gzip_extraction",
+            f"strings matching '{command_pattern}' | sort -u",
+        )
+
+    license_strings = [
+        s for s in uboot_strings if re.search(r"copyright|license|\bGPL\b", s, re.IGNORECASE)
+    ]
+    if license_strings:
+        analysis.copyright_license = license_strings[:10]
+        analysis.add_metadata(
+            "copyright_license",
+            "gzip_extraction",
+            "strings matching 'copyright|license|GPL' (case-insensitive)",
+        )
+
+    httpd_strings = [
+        s
+        for s in uboot_strings
+        if re.search(
+            r"HTTP server|start web server|httpd|HTTP ugrade|"
+            r"HTTP/1\.[01] [0-9]{3}|Start HTTP server",
+            s,
+        )
+    ]
+    if httpd_strings:
+        analysis.httpd_server = sorted(set(httpd_strings))[:20]
+        analysis.add_metadata(
+            "httpd_server",
+            "gzip_extraction",
+            "strings matching HTTP server/httpd/web server patterns",
+        )
+
+    urls: set[str] = set()
+    for s in uboot_strings:
+        for match in re.finditer(r"https?://github\.com/[\w.-]+/[\w.-]+", s):
+            urls.add(match.group())
+    if urls:
+        analysis.third_party_urls = sorted(urls)
+        analysis.add_metadata(
+            "third_party_urls",
+            "gzip_extraction",
+            "GitHub URLs extracted from embedded HTML/strings",
+        )
+
+    recovery_strings = [s for s in uboot_strings if re.match(r"boot mode: recovery", s)]
+    if recovery_strings:
+        analysis.recovery_modes = sorted(set(recovery_strings))
+        analysis.add_metadata(
+            "recovery_modes",
+            "gzip_extraction",
+            "strings matching '^boot mode: recovery'",
+        )
+
+
+def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:
+    """Analyze U-Boot bootloader in firmware and return structured results."""
+    firmware = Path(firmware_path)
+
+    analysis = UBootAnalysis(
+        firmware_file=firmware.name,
+        firmware_size=firmware.stat().st_size,
+    )
+    analysis.add_metadata("firmware_file", "filesystem", "Path(firmware).name")
+    analysis.add_metadata("firmware_size", "filesystem", "Path(firmware).stat().st_size")
+
+    offset_manager = OffsetManager(output_dir)
+    try:
+        offset_manager.load_from_shell_script()
+    except FileNotFoundError:
+        warn("Firmware offsets not found: binwalk-offsets.sh")
+        warn("Run analyze_binwalk.py first to generate offset artifacts")
+
+    section("Extracting U-Boot version")
+
+    firmware_strings = run_strings(firmware)
+    uboot_strings = _extract_uboot_version(analysis, firmware, firmware_strings, offset_manager)
+
     if uboot_strings:
-        section("Extracting U-Boot configuration")
-
-        # Extract boot commands
-        boot_commands = [s for s in uboot_strings if re.match(r"^boot(cmd|args|delay)=", s)]
-        if boot_commands:
-            analysis.boot_commands = boot_commands[:10]  # Limit to first 10
-            analysis.add_metadata(
-                "boot_commands",
-                "gzip_extraction",
-                "strings matching '^boot(cmd|args|delay)='",
-            )
-
-        # Extract environment variables (excluding boot commands)
-        env_vars = [
-            s for s in uboot_strings if re.match(r"^[a-z_]+=", s) and not s.startswith("boot")
-        ]
-        if env_vars:
-            analysis.environment_variables = env_vars[:20]  # Limit to first 20
-            analysis.add_metadata(
-                "environment_variables",
-                "gzip_extraction",
-                "strings matching '^[a-z_]+=' excluding boot commands",
-            )
-
-        # Extract supported commands
-        command_pattern = r"^(mmc|usb|tftp|nfs|dhcp|ping|md|mw|sf|nand)"
-        commands = [s for s in uboot_strings if re.match(command_pattern, s)]
-        if commands:
-            # Remove duplicates and sort
-            analysis.supported_commands = sorted(set(commands))[:20]  # Limit to first 20
-            analysis.add_metadata(
-                "supported_commands",
-                "gzip_extraction",
-                f"strings matching '{command_pattern}' | sort -u",
-            )
-
-        # Extract copyright/license information
-        license_strings = [
-            s for s in uboot_strings if re.search(r"copyright|license|\bGPL\b", s, re.IGNORECASE)
-        ]
-        if license_strings:
-            analysis.copyright_license = license_strings[:10]  # Limit to first 10
-            analysis.add_metadata(
-                "copyright_license",
-                "gzip_extraction",
-                "strings matching 'copyright|license|GPL' (case-insensitive)",
-            )
-
-        # Detect embedded HTTPD server
-        httpd_strings = [
-            s
-            for s in uboot_strings
-            if re.search(
-                r"HTTP server|start web server|httpd|HTTP ugrade|"
-                r"HTTP/1\.[01] [0-9]{3}|Start HTTP server",
-                s,
-            )
-        ]
-        if httpd_strings:
-            analysis.httpd_server = sorted(set(httpd_strings))[:20]
-            analysis.add_metadata(
-                "httpd_server",
-                "gzip_extraction",
-                "strings matching HTTP server/httpd/web server patterns",
-            )
-
-        # Extract third-party code URLs (e.g. github.com/pepe2k/u-boot_mod)
-        urls: set[str] = set()
-        for s in uboot_strings:
-            for match in re.finditer(r"https?://github\.com/[\w.-]+/[\w.-]+", s):
-                urls.add(match.group())
-        if urls:
-            analysis.third_party_urls = sorted(urls)
-            analysis.add_metadata(
-                "third_party_urls",
-                "gzip_extraction",
-                "GitHub URLs extracted from embedded HTML/strings",
-            )
-
-        # Extract recovery boot modes
-        recovery_strings = [s for s in uboot_strings if re.match(r"boot mode: recovery", s)]
-        if recovery_strings:
-            analysis.recovery_modes = sorted(set(recovery_strings))
-            analysis.add_metadata(
-                "recovery_modes",
-                "gzip_extraction",
-                "strings matching '^boot mode: recovery'",
-            )
+        _parse_uboot_strings(analysis, uboot_strings)
 
     if not analysis.version:
         warn("Could not extract U-Boot version")
@@ -276,7 +281,45 @@ def analyze_uboot(firmware_path: str, output_dir: Path) -> UBootAnalysis:  # noq
     return analysis
 
 
-def write_legacy_markdown(analysis: UBootAnalysis, output_dir: Path) -> None:  # noqa: PLR0912, PLR0915
+def _write_uboot_strings_section(f: Any, analysis: UBootAnalysis) -> None:
+    """Write U-Boot strings analysis sections (boot commands, env vars, etc.)."""
+    if analysis.boot_commands:
+        f.write("### Boot Commands\n")
+        f.write("\n")
+        f.write("```\n")
+        for cmd in analysis.boot_commands:
+            f.write(f"{cmd}\n")
+        f.write("```\n")
+        f.write("\n")
+
+    if analysis.environment_variables:
+        f.write("### Environment Variables\n")
+        f.write("\n")
+        f.write("```\n")
+        for var in analysis.environment_variables:
+            f.write(f"{var}\n")
+        f.write("```\n")
+        f.write("\n")
+
+    if analysis.supported_commands:
+        f.write("### Supported Commands\n")
+        f.write("\n")
+        f.write("```\n")
+        for cmd in analysis.supported_commands:
+            f.write(f"{cmd}\n")
+        f.write("```\n")
+        f.write("\n")
+
+    if analysis.copyright_license:
+        f.write("### Copyright/License\n")
+        f.write("\n")
+        f.write("```\n")
+        for line in analysis.copyright_license:
+            f.write(f"{line}\n")
+        f.write("```\n")
+
+
+def write_legacy_markdown(analysis: UBootAnalysis, output_dir: Path) -> None:
     """Write uboot-version.md for backward compatibility."""
     markdown_file = output_dir / "uboot-version.md"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -310,45 +353,11 @@ def write_legacy_markdown(analysis: UBootAnalysis, output_dir: Path) -> None:  #
 
         f.write("\n")
 
-        # U-Boot Strings Analysis
         f.write("## U-Boot Strings Analysis\n")
         f.write("\n")
 
         if analysis.boot_commands or analysis.environment_variables or analysis.supported_commands:
-            if analysis.boot_commands:
-                f.write("### Boot Commands\n")
-                f.write("\n")
-                f.write("```\n")
-                for cmd in analysis.boot_commands:
-                    f.write(f"{cmd}\n")
-                f.write("```\n")
-                f.write("\n")
-
-            if analysis.environment_variables:
-                f.write("### Environment Variables\n")
-                f.write("\n")
-                f.write("```\n")
-                for var in analysis.environment_variables:
-                    f.write(f"{var}\n")
-                f.write("```\n")
-                f.write("\n")
-
-            if analysis.supported_commands:
-                f.write("### Supported Commands\n")
-                f.write("\n")
-                f.write("```\n")
-                for cmd in analysis.supported_commands:
-                    f.write(f"{cmd}\n")
-                f.write("```\n")
-                f.write("\n")
-
-            if analysis.copyright_license:
-                f.write("### Copyright/License\n")
-                f.write("\n")
-                f.write("```\n")
-                for line in analysis.copyright_license:
-                    f.write(f"{line}\n")
-                f.write("```\n")
+            _write_uboot_strings_section(f, analysis)
         else:
             f.write("*Could not extract U-Boot binary for detailed analysis*\n")
 

--- a/scripts/lib/output.py
+++ b/scripts/lib/output.py
@@ -18,7 +18,51 @@ TOML_MAX_COMMENT_LENGTH = 80
 TOML_COMMENT_TRUNCATE_LENGTH = 77
 
 
-def output_toml(  # noqa: PLR0912
+def _auto_detect_fields(data: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Classify data fields into simple (primitives) and complex (lists/dicts).
+
+    Returns:
+        Tuple of (simple_fields, complex_fields)
+    """
+    simple: list[str] = []
+    complex_: list[str] = []
+
+    for key, value in data.items():
+        if key.endswith("_source") or key.endswith("_method"):
+            continue
+
+        if isinstance(value, list | dict):
+            complex_.append(key)
+        else:
+            simple.append(key)
+
+    return simple, complex_
+
+
+def _add_simple_fields(
+    doc: tomlkit.TOMLDocument, data: dict[str, Any], simple_fields: list[str]
+) -> None:
+    """Add simple fields with source metadata comments to TOML document."""
+    for key in simple_fields:
+        if key not in data:
+            continue
+
+        value = data[key]
+
+        if f"{key}_source" in data:
+            doc.add(tomlkit.comment(f"Source: {data[f'{key}_source']}"))
+        if f"{key}_method" in data:
+            method = data[f"{key}_method"]
+            if len(method) > TOML_MAX_COMMENT_LENGTH:
+                doc.add(tomlkit.comment(f"Method: {method[:TOML_COMMENT_TRUNCATE_LENGTH]}..."))
+            else:
+                doc.add(tomlkit.comment(f"Method: {method}"))
+
+        doc.add(key, value)
+        doc.add(tomlkit.nl())
+
+
+def output_toml(
     analysis: Any,
     title: str,
     simple_fields: list[str] | None = None,
@@ -49,51 +93,20 @@ def output_toml(  # noqa: PLR0912
 
     # Auto-detect simple vs complex fields if not provided
     if simple_fields is None or complex_fields is None:
-        auto_simple: list[str] = []
-        auto_complex: list[str] = []
-
-        for key, value in data.items():
-            # Skip metadata fields
-            if key.endswith("_source") or key.endswith("_method"):
-                continue
-
-            # Classify by type
-            if isinstance(value, list | dict):
-                auto_complex.append(key)
-            else:
-                auto_simple.append(key)
-
+        auto_simple, auto_complex = _auto_detect_fields(data)
         if simple_fields is None:
             simple_fields = auto_simple
         if complex_fields is None:
             complex_fields = auto_complex
 
     # Add simple fields first (primitives with metadata comments)
-    for key in simple_fields:
-        if key not in data:
-            continue
-
-        value = data[key]
-
-        # Add source metadata as comment
-        if f"{key}_source" in data:
-            doc.add(tomlkit.comment(f"Source: {data[f'{key}_source']}"))
-        if f"{key}_method" in data:
-            method = data[f"{key}_method"]
-            if len(method) > TOML_MAX_COMMENT_LENGTH:
-                doc.add(tomlkit.comment(f"Method: {method[:TOML_COMMENT_TRUNCATE_LENGTH]}..."))
-            else:
-                doc.add(tomlkit.comment(f"Method: {method}"))
-
-        doc.add(key, value)
-        doc.add(tomlkit.nl())
+    _add_simple_fields(doc, data, simple_fields)
 
     # Add complex fields (arrays/objects with header comments)
     for key in complex_fields:
         if key not in data or not data[key]:
             continue
 
-        # Add descriptive header comment
         doc.add(tomlkit.comment(key.replace("_", " ").title()))
         doc.add(key, data[key])
         doc.add(tomlkit.nl())

--- a/tests/test_analyze_network_services.py
+++ b/tests/test_analyze_network_services.py
@@ -1038,9 +1038,7 @@ user:!:19001:0:99999:7:::
         return rootfs
 
     @patch("subprocess.run")
-    def test_realistic_network_services_analysis(
-        self, mock_run: Any, tmp_path: Path
-    ) -> None:
+    def test_realistic_network_services_analysis(self, mock_run: Any, tmp_path: Path) -> None:
         """Test complete analysis workflow with realistic filesystem."""
         rootfs = self._setup_network_rootfs(tmp_path)
 

--- a/tests/test_analyze_network_services.py
+++ b/tests/test_analyze_network_services.py
@@ -995,12 +995,9 @@ class TestOutputToml:
 class TestIntegration:
     """Integration tests with realistic data."""
 
-    @patch("subprocess.run")
-    def test_realistic_network_services_analysis(  # noqa: PLR0915
-        self, mock_run: Any, tmp_path: Path
-    ) -> None:
-        """Test complete analysis workflow with realistic filesystem."""
-        # Create realistic filesystem structure
+    @staticmethod
+    def _setup_network_rootfs(tmp_path: Path) -> Path:
+        """Create a realistic rootfs with network services for integration testing."""
         rootfs = tmp_path / "squashfs-root"
 
         # Create init scripts
@@ -1035,9 +1032,20 @@ user:!:19001:0:99999:7:::
         # Create firewall config
         (etc / "firewall").write_text("config defaults")
 
+        # Create sensitive config file
+        (etc / "config").write_text("password=secret")
+
+        return rootfs
+
+    @patch("subprocess.run")
+    def test_realistic_network_services_analysis(
+        self, mock_run: Any, tmp_path: Path
+    ) -> None:
+        """Test complete analysis workflow with realistic filesystem."""
+        rootfs = self._setup_network_rootfs(tmp_path)
+
         # Mock grep for sensitive files
-        config_file = etc / "config"
-        config_file.write_text("password=secret")
+        config_file = rootfs / "etc" / "config"
         mock_run.return_value = MagicMock(stdout=str(config_file), returncode=0)
 
         # Create analysis object

--- a/tests/test_analyze_proprietary_blobs.py
+++ b/tests/test_analyze_proprietary_blobs.py
@@ -1071,13 +1071,9 @@ class TestOutputToml:
 class TestIntegration:
     """Integration tests with realistic data."""
 
-    @patch("analyze_proprietary_blobs.has_gpl_string")
-    @patch("subprocess.run")
-    def test_realistic_proprietary_blobs_analysis(  # noqa: PLR0915
-        self, mock_run: Any, mock_has_gpl: Any, tmp_path: Path
-    ) -> None:
-        """Test complete analysis workflow with realistic filesystem."""
-        # Create realistic filesystem structure
+    @staticmethod
+    def _setup_blobs_rootfs(tmp_path: Path) -> Path:
+        """Create a realistic rootfs with proprietary blobs for integration testing."""
         rootfs = tmp_path / "squashfs-root"
 
         # Create Rockchip libraries
@@ -1102,6 +1098,16 @@ class TestIntegration:
         modules_dir.mkdir(parents=True)
         (modules_dir / "rockchip_vpu.ko").write_bytes(b"x" * 102400)
         (modules_dir / "dwc3.ko").write_bytes(b"x" * 51200)
+
+        return rootfs
+
+    @patch("analyze_proprietary_blobs.has_gpl_string")
+    @patch("subprocess.run")
+    def test_realistic_proprietary_blobs_analysis(
+        self, mock_run: Any, mock_has_gpl: Any, tmp_path: Path
+    ) -> None:
+        """Test complete analysis workflow with realistic filesystem."""
+        rootfs = self._setup_blobs_rootfs(tmp_path)
 
         # Mock GPL detection
         mock_has_gpl.side_effect = [True, False]
@@ -1175,7 +1181,6 @@ class TestIntegration:
         assert analysis.binary_analysis is not None
 
         # Verify TOML output
-
         toml_str = output_toml(
             analysis,
             title="Test",


### PR DESCRIPTION
## Summary

- Remove all `# noqa: PLR0912, PLR0915` suppressions by extracting private helper functions
- 12 violations across 7 functions in 7 files, all resolved
- Pure mechanical extraction — no behavior changes

## Changes

| File | Helpers Extracted |
|------|-------------------|
| `scripts/analyze_boot_process.py` | `_write_hardware_table`, `_write_partitions_table`, `_write_fit_section`, `_write_boot_config` |
| `scripts/analyze_uboot.py` | `_extract_uboot_version`, `_parse_uboot_strings`, `_write_uboot_strings_section` |
| `scripts/analyze_network_services.py` | `_scan_network_services` |
| `scripts/analyze_secure_boot.py` | `_analyze_uboot_strings`, `_analyze_optee_strings` |
| `scripts/lib/output.py` | `_auto_detect_fields`, `_add_simple_fields` |
| `tests/test_analyze_network_services.py` | `_setup_network_rootfs` |
| `tests/test_analyze_proprietary_blobs.py` | `_setup_blobs_rootfs` |

## Test plan

- [x] All 681 existing tests pass (no new tests needed — existing coverage is complete)
- [x] `ruff check --select PLR0912,PLR0915 --ignore-noqa scripts/ tests/` → 0 violations
- [x] `grep -r 'noqa.*PLR091[25]' scripts/ tests/` → no matches
- [x] `ruff format` clean

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)