### PR TITLE
feat: Add reproducibility metadata to analysis framework

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -120,9 +120,19 @@ def convert_to_tracked_values(result: dict[str, Any], analysis_type: str) -> dic
     """
     tracked_result = {}
 
+    metadata_suffixes = (
+        "_source",
+        "_method",
+        "_reproducibility",
+        "_equipment",
+        "_procedure",
+        "_performed",
+        "_operator",
+    )
+
     for key, value in result.items():
         # Skip metadata keys
-        if key.endswith("_source") or key.endswith("_method"):
+        if any(key.endswith(suffix) for suffix in metadata_suffixes):
             continue
 
         # Check for source/method metadata

--- a/scripts/analyze_binwalk.py
+++ b/scripts/analyze_binwalk.py
@@ -64,6 +64,8 @@ class BinwalkAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_boot_process.py
+++ b/scripts/analyze_boot_process.py
@@ -106,6 +106,8 @@ class BootProcessAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_device_trees.py
+++ b/scripts/analyze_device_trees.py
@@ -57,6 +57,8 @@ class DeviceTreeAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_network_services.py
+++ b/scripts/analyze_network_services.py
@@ -102,6 +102,8 @@ class NetworkServicesAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_proprietary_blobs.py
+++ b/scripts/analyze_proprietary_blobs.py
@@ -104,6 +104,8 @@ class ProprietaryBlobsAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_rootfs.py
+++ b/scripts/analyze_rootfs.py
@@ -102,6 +102,8 @@ class RootfsAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_secure_boot.py
+++ b/scripts/analyze_secure_boot.py
@@ -67,6 +67,8 @@ class SecureBootAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
         """Convert complex fields to serializable format."""

--- a/scripts/analyze_uboot.py
+++ b/scripts/analyze_uboot.py
@@ -76,6 +76,8 @@ class UBootAnalysis(AnalysisBase):
     # Source metadata for each field
     _source: dict[str, str] = field(default_factory=dict)
     _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
 def run_strings(firmware: Path) -> str:

--- a/scripts/lib/analysis_base.py
+++ b/scripts/lib/analysis_base.py
@@ -22,6 +22,8 @@ class AnalysisBase:
             field2: int
             _source: dict[str, str] = field(default_factory=dict)
             _method: dict[str, str] = field(default_factory=dict)
+            _reproducibility: dict[str, str] = field(default_factory=dict)
+            _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
             def _convert_complex_field(
                 self, key: str, value: Any
@@ -34,20 +36,65 @@ class AnalysisBase:
 
     _source: dict[str, str]
     _method: dict[str, str]
+    _reproducibility: dict[str, str]
+    _hardware_metadata: dict[str, dict[str, str]]
 
-    def add_metadata(self, field_name: str, source: str, method: str) -> None:
+    def add_metadata(
+        self,
+        field_name: str,
+        source: str,
+        method: str,
+        reproducibility: str = "software",
+    ) -> None:
         """Add source metadata for a field.
 
         Args:
             field_name: Name of the field
             source: Source of the data (e.g., "U-Boot", "DTS")
             method: Method used to extract data (e.g., "strings | grep")
+            reproducibility: Reproducibility class ("software" or "hardware")
         """
         self._source[field_name] = source
         self._method[field_name] = method
+        self._reproducibility[field_name] = reproducibility
+
+    def add_hardware_metadata(
+        self,
+        field_name: str,
+        source: str,
+        method: str,
+        *,
+        equipment: str,
+        procedure: str,
+        performed: str,
+        operator: str,
+    ) -> None:
+        """Add hardware-dependent metadata for a field.
+
+        Args:
+            field_name: Name of the field
+            source: Source of the data
+            method: Method used to extract data
+            equipment: Equipment used (e.g., "UART adapter")
+            procedure: Procedure followed
+            performed: Date performed
+            operator: Person who performed the measurement
+        """
+        self.add_metadata(field_name, source, method, reproducibility="hardware")
+        self._hardware_metadata[field_name] = {
+            "equipment": equipment,
+            "procedure": procedure,
+            "performed": performed,
+            "operator": operator,
+        }
 
     def set_count_with_metadata(
-        self, field_name: str, items: list[Any], source: str, method: str
+        self,
+        field_name: str,
+        items: list[Any],
+        source: str,
+        method: str,
+        reproducibility: str = "software",
     ) -> None:
         """Set a count field to len(items) and add metadata.
 
@@ -58,9 +105,10 @@ class AnalysisBase:
             items: List to count
             source: Source of the data (e.g., "filesystem")
             method: Method used to extract data (e.g., "find ... -name '*.dtb'")
+            reproducibility: Reproducibility class ("software" or "hardware")
         """
         setattr(self, field_name, len(items))
-        self.add_metadata(field_name, source, method)
+        self.add_metadata(field_name, source, method, reproducibility)
 
     def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:  # noqa: ARG002
         """Convert a complex field to a serializable format.
@@ -112,5 +160,11 @@ class AnalysisBase:
                     result[f"{key}_source"] = self._source[key]
                 if key in self._method:
                     result[f"{key}_method"] = self._method[key]
+                if key in self._reproducibility:
+                    result[f"{key}_reproducibility"] = self._reproducibility[key]
+                if key in self._hardware_metadata:
+                    hw = self._hardware_metadata[key]
+                    for hw_key in ("equipment", "procedure", "performed", "operator"):
+                        result[f"{key}_{hw_key}"] = hw[hw_key]
 
         return result

--- a/scripts/lib/output.py
+++ b/scripts/lib/output.py
@@ -17,6 +17,17 @@ from .logging import error
 TOML_MAX_COMMENT_LENGTH = 80
 TOML_COMMENT_TRUNCATE_LENGTH = 77
 
+# Metadata suffix patterns used to identify metadata keys
+METADATA_SUFFIXES = (
+    "_source",
+    "_method",
+    "_reproducibility",
+    "_equipment",
+    "_procedure",
+    "_performed",
+    "_operator",
+)
+
 
 def _auto_detect_fields(data: dict[str, Any]) -> tuple[list[str], list[str]]:
     """Classify data fields into simple (primitives) and complex (lists/dicts).
@@ -28,9 +39,10 @@ def _auto_detect_fields(data: dict[str, Any]) -> tuple[list[str], list[str]]:
     complex_: list[str] = []
 
     for key, value in data.items():
-        # Skip metadata keys: {field}_source and {field}_method where {field} is another key
-        if key.endswith("_source") or key.endswith("_method"):
-            base_key = key.rsplit("_", 1)[0]
+        # Skip metadata keys where the base field exists in data
+        if any(key.endswith(suffix) for suffix in METADATA_SUFFIXES):
+            suffix = next(s for s in METADATA_SUFFIXES if key.endswith(s))
+            base_key = key[: -len(suffix)]
             if base_key in data:
                 continue
 
@@ -60,6 +72,15 @@ def _add_simple_fields(
                 doc.add(tomlkit.comment(f"Method: {method[:TOML_COMMENT_TRUNCATE_LENGTH]}..."))
             else:
                 doc.add(tomlkit.comment(f"Method: {method}"))
+        if f"{key}_reproducibility" in data:
+            doc.add(tomlkit.comment(f"Reproducibility: {data[f'{key}_reproducibility']}"))
+        for hw_field in ("equipment", "procedure", "performed", "operator"):
+            hw_key = f"{key}_{hw_field}"
+            if hw_key in data:
+                val = data[hw_key]
+                if len(val) > TOML_MAX_COMMENT_LENGTH:
+                    val = val[:TOML_COMMENT_TRUNCATE_LENGTH] + "..."
+                doc.add(tomlkit.comment(f"{hw_field.title()}: {val}"))
 
         doc.add(key, value)
         doc.add(tomlkit.nl())

--- a/tests/test_analysis_base.py
+++ b/tests/test_analysis_base.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/analysis_base.py — reproducibility and hardware metadata."""
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from lib.analysis_base import AnalysisBase
+from lib.output import output_toml
+
+
+@dataclass
+class SampleAnalysis(AnalysisBase):
+    """Minimal analysis dataclass for testing."""
+
+    version: str | None = None
+    offset: int | None = None
+
+    _source: dict[str, str] = field(default_factory=dict)
+    _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:  # noqa: ARG002
+        return False, None
+
+
+class TestReproducibilityMetadata:
+    """Test reproducibility metadata tracking."""
+
+    def test_default_reproducibility_is_software(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep")
+        assert analysis._reproducibility["version"] == "software"
+
+    def test_explicit_software_reproducibility(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep", reproducibility="software")
+        assert analysis._reproducibility["version"] == "software"
+
+    def test_explicit_hardware_reproducibility(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "UART capture", reproducibility="hardware")
+        assert analysis._reproducibility["version"] == "hardware"
+
+    def test_to_dict_emits_reproducibility(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep")
+        d = analysis.to_dict()
+        assert d["version_reproducibility"] == "software"
+
+    def test_backward_compat_three_arg_add_metadata(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep")
+        d = analysis.to_dict()
+        assert d["version_source"] == "firmware"
+        assert d["version_method"] == "strings | grep"
+        assert d["version_reproducibility"] == "software"
+
+
+class TestHardwareMetadata:
+    """Test hardware-dependent metadata tracking."""
+
+    def test_add_hardware_metadata_sets_all_fields(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.offset = 0x100
+        analysis.add_hardware_metadata(
+            "offset",
+            "UART log",
+            "serial console capture",
+            equipment="USB-UART adapter",
+            procedure="Boot with UART connected at 115200 baud",
+            performed="2025-01-15",
+            operator="Test Engineer",
+        )
+        assert analysis._reproducibility["offset"] == "hardware"
+        assert analysis._hardware_metadata["offset"]["equipment"] == "USB-UART adapter"
+        expected_procedure = "Boot with UART connected at 115200 baud"
+        assert analysis._hardware_metadata["offset"]["procedure"] == expected_procedure
+        assert analysis._hardware_metadata["offset"]["performed"] == "2025-01-15"
+        assert analysis._hardware_metadata["offset"]["operator"] == "Test Engineer"
+
+    def test_to_dict_emits_hardware_fields(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.offset = 0x100
+        analysis.add_hardware_metadata(
+            "offset",
+            "UART log",
+            "serial console capture",
+            equipment="USB-UART adapter",
+            procedure="Boot capture",
+            performed="2025-01-15",
+            operator="Test Engineer",
+        )
+        d = analysis.to_dict()
+        assert d["offset_reproducibility"] == "hardware"
+        assert d["offset_equipment"] == "USB-UART adapter"
+        assert d["offset_procedure"] == "Boot capture"
+        assert d["offset_performed"] == "2025-01-15"
+        assert d["offset_operator"] == "Test Engineer"
+
+
+class TestReproducibilityTomlOutput:
+    """Test TOML output includes reproducibility metadata as comments."""
+
+    def test_toml_has_reproducibility_comment(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep")
+        toml_str = output_toml(analysis, "Test")
+        assert "# Reproducibility: software" in toml_str
+
+    def test_toml_hardware_fields_render_as_comments(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.offset = 256
+        analysis.add_hardware_metadata(
+            "offset",
+            "UART log",
+            "serial console capture",
+            equipment="USB-UART adapter",
+            procedure="Boot capture",
+            performed="2025-01-15",
+            operator="Test Engineer",
+        )
+        toml_str = output_toml(analysis, "Test")
+        assert "# Reproducibility: hardware" in toml_str
+        assert "# Equipment: USB-UART adapter" in toml_str
+        assert "# Procedure: Boot capture" in toml_str
+        assert "# Performed: 2025-01-15" in toml_str
+        assert "# Operator: Test Engineer" in toml_str
+
+    def test_metadata_keys_dont_leak_as_toml_fields(self) -> None:
+        analysis = SampleAnalysis()
+        analysis.version = "1.0"
+        analysis.add_metadata("version", "firmware", "strings | grep")
+        toml_str = output_toml(analysis, "Test")
+        parsed = tomlkit.loads(toml_str)
+        # Only the actual field should appear as a TOML key
+        assert "version" in parsed
+        # Metadata should be comments, not keys
+        assert "version_source" not in parsed
+        assert "version_method" not in parsed
+        assert "version_reproducibility" not in parsed


### PR DESCRIPTION
## Summary
- Extend `AnalysisBase` with reproducibility classification (`software`/`hardware`) and hardware-dependent metadata fields (`equipment`, `procedure`, `performed`, `operator`)
- Update TOML output to render reproducibility and hardware metadata as comments
- Extend metadata suffix detection in `output.py` and `analysis.py` to handle all new suffixes
- Add `_reproducibility` and `_hardware_metadata` fields to all 8 analysis dataclasses

Closes #95

## Test plan
- [x] 10 new tests in `tests/test_analysis_base.py` covering reproducibility defaults, hardware metadata, and TOML output
- [x] All 724 existing + new tests pass
- [x] Zero ruff lint/format errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)