### PR TITLE
fix: Emit metadata for complex fields in TOML output

### DIFF
--- a/results/binwalk.toml
+++ b/results/binwalk.toml
@@ -1,5 +1,0 @@
-warning: unhandled Platform key FamilyDisplayName
-Traceback (most recent call last):
-  File "/Users/hays/Projects/glinet-comet-reversing/scripts/analyze-binwalk.py", line 26, in <module>
-    import tomlkit
-ModuleNotFoundError: No module named 'tomlkit'

--- a/scripts/analyze_binwalk.py
+++ b/scripts/analyze_binwalk.py
@@ -165,6 +165,7 @@ def analyze_firmware(firmware_path: str) -> BinwalkAnalysis:
 
     # Parse components
     analysis.identified_components = parse_binwalk_output(binwalk_output)
+    analysis.add_metadata("identified_components", "binwalk", "binwalk output parsing")
 
     # Count component types (case-insensitive)
     analysis.squashfs_count = sum(

--- a/scripts/analyze_device_trees.py
+++ b/scripts/analyze_device_trees.py
@@ -197,6 +197,8 @@ def analyze_device_trees(firmware_path: str, work_dir: Path) -> DeviceTreeAnalys
         device_tree = analyze_dtb_file(dtb_path, extract_dir)
         analysis.device_trees.append(device_tree)
 
+    analysis.add_metadata("device_trees", "binwalk", "DTB extraction from firmware partitions")
+
     return analysis
 
 

--- a/scripts/lib/analysis_base.py
+++ b/scripts/lib/analysis_base.py
@@ -155,16 +155,16 @@ class AnalysisBase:
                 # Default: just use the value as-is
                 result[key] = value
 
-                # Add source metadata for simple fields
-                if key in self._source:
-                    result[f"{key}_source"] = self._source[key]
-                if key in self._method:
-                    result[f"{key}_method"] = self._method[key]
-                if key in self._reproducibility:
-                    result[f"{key}_reproducibility"] = self._reproducibility[key]
-                if key in self._hardware_metadata:
-                    hw = self._hardware_metadata[key]
-                    for hw_key in ("equipment", "procedure", "performed", "operator"):
-                        result[f"{key}_{hw_key}"] = hw[hw_key]
+            # Add source metadata for all fields (simple and complex)
+            if key in self._source:
+                result[f"{key}_source"] = self._source[key]
+            if key in self._method:
+                result[f"{key}_method"] = self._method[key]
+            if key in self._reproducibility:
+                result[f"{key}_reproducibility"] = self._reproducibility[key]
+            if key in self._hardware_metadata:
+                hw = self._hardware_metadata[key]
+                for hw_key in ("equipment", "procedure", "performed", "operator"):
+                    result[f"{key}_{hw_key}"] = hw[hw_key]
 
         return result

--- a/scripts/lib/output.py
+++ b/scripts/lib/output.py
@@ -54,6 +54,27 @@ def _auto_detect_fields(data: dict[str, Any]) -> tuple[list[str], list[str]]:
     return simple, complex_
 
 
+def _add_metadata_comments(doc: tomlkit.TOMLDocument, data: dict[str, Any], key: str) -> None:
+    """Add source/method/reproducibility/hardware metadata comments for a field."""
+    if f"{key}_source" in data:
+        doc.add(tomlkit.comment(f"Source: {data[f'{key}_source']}"))
+    if f"{key}_method" in data:
+        method = data[f"{key}_method"]
+        if len(method) > TOML_MAX_COMMENT_LENGTH:
+            doc.add(tomlkit.comment(f"Method: {method[:TOML_COMMENT_TRUNCATE_LENGTH]}..."))
+        else:
+            doc.add(tomlkit.comment(f"Method: {method}"))
+    if f"{key}_reproducibility" in data:
+        doc.add(tomlkit.comment(f"Reproducibility: {data[f'{key}_reproducibility']}"))
+    for hw_field in ("equipment", "procedure", "performed", "operator"):
+        hw_key = f"{key}_{hw_field}"
+        if hw_key in data:
+            val = data[hw_key]
+            if len(val) > TOML_MAX_COMMENT_LENGTH:
+                val = val[:TOML_COMMENT_TRUNCATE_LENGTH] + "..."
+            doc.add(tomlkit.comment(f"{hw_field.title()}: {val}"))
+
+
 def _add_simple_fields(
     doc: tomlkit.TOMLDocument, data: dict[str, Any], simple_fields: list[str]
 ) -> None:
@@ -63,25 +84,7 @@ def _add_simple_fields(
             continue
 
         value = data[key]
-
-        if f"{key}_source" in data:
-            doc.add(tomlkit.comment(f"Source: {data[f'{key}_source']}"))
-        if f"{key}_method" in data:
-            method = data[f"{key}_method"]
-            if len(method) > TOML_MAX_COMMENT_LENGTH:
-                doc.add(tomlkit.comment(f"Method: {method[:TOML_COMMENT_TRUNCATE_LENGTH]}..."))
-            else:
-                doc.add(tomlkit.comment(f"Method: {method}"))
-        if f"{key}_reproducibility" in data:
-            doc.add(tomlkit.comment(f"Reproducibility: {data[f'{key}_reproducibility']}"))
-        for hw_field in ("equipment", "procedure", "performed", "operator"):
-            hw_key = f"{key}_{hw_field}"
-            if hw_key in data:
-                val = data[hw_key]
-                if len(val) > TOML_MAX_COMMENT_LENGTH:
-                    val = val[:TOML_COMMENT_TRUNCATE_LENGTH] + "..."
-                doc.add(tomlkit.comment(f"{hw_field.title()}: {val}"))
-
+        _add_metadata_comments(doc, data, key)
         doc.add(key, value)
         doc.add(tomlkit.nl())
 
@@ -131,6 +134,7 @@ def output_toml(
         if key not in data or not data[key]:
             continue
 
+        _add_metadata_comments(doc, data, key)
         doc.add(tomlkit.comment(key.replace("_", " ").title()))
         doc.add(key, data[key])
         doc.add(tomlkit.nl())

--- a/tests/test_analysis_base.py
+++ b/tests/test_analysis_base.py
@@ -30,6 +30,24 @@ class SampleAnalysis(AnalysisBase):
         return False, None
 
 
+@dataclass
+class SampleWithListAnalysis(AnalysisBase):
+    """Analysis dataclass with a complex (list) field for testing."""
+
+    name: str | None = None
+    items: list[dict[str, str]] = field(default_factory=list)
+
+    _source: dict[str, str] = field(default_factory=dict)
+    _method: dict[str, str] = field(default_factory=dict)
+    _reproducibility: dict[str, str] = field(default_factory=dict)
+    _hardware_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    def _convert_complex_field(self, key: str, value: Any) -> tuple[bool, Any]:
+        if key == "items":
+            return True, value
+        return False, None
+
+
 class TestReproducibilityMetadata:
     """Test reproducibility metadata tracking."""
 
@@ -151,3 +169,50 @@ class TestReproducibilityTomlOutput:
         assert "version_source" not in parsed
         assert "version_method" not in parsed
         assert "version_reproducibility" not in parsed
+
+
+class TestComplexFieldMetadata:
+    """Test metadata tracking for complex (list/dict) fields."""
+
+    def test_to_dict_emits_metadata_for_complex_fields(self) -> None:
+        analysis = SampleWithListAnalysis()
+        analysis.name = "test"
+        analysis.items = [{"key": "value"}]
+        analysis.add_metadata("items", "binwalk", "output parsing")
+        d = analysis.to_dict()
+        assert d["items_source"] == "binwalk"
+        assert d["items_method"] == "output parsing"
+        assert d["items_reproducibility"] == "software"
+
+    def test_toml_renders_metadata_comments_for_complex_fields(self) -> None:
+        analysis = SampleWithListAnalysis()
+        analysis.name = "test"
+        analysis.items = [{"key": "value"}]
+        analysis.add_metadata("items", "binwalk", "output parsing")
+        toml_str = output_toml(analysis, "Test")
+        assert "# Source: binwalk" in toml_str
+        assert "# Method: output parsing" in toml_str
+        assert "# Reproducibility: software" in toml_str
+
+    def test_toml_complex_field_metadata_appears_before_section(self) -> None:
+        analysis = SampleWithListAnalysis()
+        analysis.name = "test"
+        analysis.items = [{"key": "value"}]
+        analysis.add_metadata("items", "binwalk", "output parsing")
+        toml_str = output_toml(analysis, "Test")
+        # Metadata comments should appear before the section header
+        source_pos = toml_str.index("# Source: binwalk")
+        header_pos = toml_str.index("# Items")
+        assert source_pos < header_pos
+
+    def test_toml_complex_field_metadata_keys_not_in_parsed(self) -> None:
+        analysis = SampleWithListAnalysis()
+        analysis.name = "test"
+        analysis.items = [{"key": "value"}]
+        analysis.add_metadata("items", "binwalk", "output parsing")
+        toml_str = output_toml(analysis, "Test")
+        parsed = tomlkit.loads(toml_str)
+        assert "items" in parsed
+        assert "items_source" not in parsed
+        assert "items_method" not in parsed
+        assert "items_reproducibility" not in parsed


### PR DESCRIPTION
## Summary

Closes #99

- **Fix `to_dict()` metadata for complex fields**: Metadata (source/method/reproducibility/hardware) was only emitted for simple fields; complex fields handled by `_convert_complex_field()` silently dropped it. Moved metadata emission outside the if/else branch.
- **Fix `output_toml()` complex field comments**: Extracted `_add_metadata_comments()` helper from `_add_simple_fields()` and added a call in the complex fields loop so Source/Method/Reproducibility comments render before array sections.
- **Add missing `add_metadata()` calls**: `analyze_binwalk.py` (`identified_components`) and `analyze_device_trees.py` (`device_trees`) now track their source metadata.
- **Delete corrupted `results/binwalk.toml`**: Contained a Python traceback from a removed script, not valid TOML.
- **Add tests**: 4 new tests in `TestComplexFieldMetadata` covering `to_dict()` emission, TOML comment rendering, comment ordering, and metadata key filtering.

## Test plan

- [x] `uv run pytest` — 728 tests pass
- [x] `uv run ruff check scripts/ tests/` — clean
- [x] `uv run ruff format --check scripts/ tests/` — clean
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)