### PR TITLE
feat: Add firmware SHA256 and U-Boot build metadata (#108)

### DIFF
--- a/scripts/analyze_binwalk.py
+++ b/scripts/analyze_binwalk.py
@@ -165,11 +165,13 @@ def analyze_firmware(firmware_path: str) -> BinwalkAnalysis:
     analysis.add_metadata("firmware_file", "binwalk", "Path(firmware).name")
     analysis.add_metadata("firmware_size", "binwalk", "Path(firmware).stat().st_size")
 
-    # Compute firmware SHA256 hash
-    analysis.firmware_sha256 = hashlib.sha256(firmware.read_bytes()).hexdigest()
-    analysis.add_metadata(
-        "firmware_sha256", "filesystem", "hashlib.sha256(firmware.read_bytes()).hexdigest()"
-    )
+    # Compute firmware SHA256 hash (chunked to avoid loading entire file into memory)
+    sha256 = hashlib.sha256()
+    with firmware.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            sha256.update(chunk)
+    analysis.firmware_sha256 = sha256.hexdigest()
+    analysis.add_metadata("firmware_sha256", "filesystem", "hashlib.sha256 (chunked read)")
 
     # Parse components
     analysis.identified_components = parse_binwalk_output(binwalk_output)

--- a/scripts/analyze_uboot.py
+++ b/scripts/analyze_uboot.py
@@ -170,19 +170,19 @@ def _extract_uboot_version(
 
     # Extract git commit hash from version string (e.g., "2017.09-gfd8bfa2acd-dirty")
     if analysis.version:
-        git_match = re.search(r"-g([0-9a-f]+)", analysis.version)
+        git_match = re.search(r"-g([0-9a-f]{7,40})(?:-|$|\s)", analysis.version)
         if git_match:
             analysis.uboot_git_commit = git_match.group(1)
             analysis.add_metadata(
                 "uboot_git_commit",
                 analysis._source.get("version", "strings"),
-                "regex '-g([0-9a-f]+)' on version string",
+                "regex '-g([0-9a-f]{7,40})' on version string",
             )
 
     # Parse build date to cleaner format from "(Mon DD YYYY - HH:MM:SS +ZZZZ)"
     if analysis.build_date:
         date_match = re.match(
-            r"\((\w+ \d+ \d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", analysis.build_date
+            r"\((\w+\s+\d+\s+\d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", analysis.build_date
         )
         if date_match:
             analysis.uboot_build_date = date_match.group(1)

--- a/tests/test_analyze_binwalk.py
+++ b/tests/test_analyze_binwalk.py
@@ -65,19 +65,24 @@ class TestBinwalkAnalysis:
         analysis = BinwalkAnalysis(firmware_file="test.img", firmware_size=1024)
         assert analysis.firmware_sha256 is None
 
-    def test_firmware_sha256_computation(self) -> None:
-        """Test SHA256 computation on a known file."""
-        content = b"test firmware content"
-        expected_hash = hashlib.sha256(content).hexdigest()
+    def test_firmware_sha256_chunked_matches_whole_file(self) -> None:
+        """Test that chunked SHA256 produces same result as whole-file hash."""
+        content = b"test firmware content" * 1000
 
         with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as f:
             f.write(content)
             tmp_path = Path(f.name)
 
         try:
-            computed_hash = hashlib.sha256(tmp_path.read_bytes()).hexdigest()
-            assert computed_hash == expected_hash
-            assert len(computed_hash) == 64  # SHA256 hex digest is 64 chars
+            # Whole-file reference hash
+            expected = hashlib.sha256(content).hexdigest()
+            # Chunked hash (same approach as production code)
+            sha256 = hashlib.sha256()
+            with tmp_path.open("rb") as fh:
+                for chunk in iter(lambda: fh.read(65536), b""):
+                    sha256.update(chunk)
+            assert sha256.hexdigest() == expected
+            assert len(expected) == 64
         finally:
             tmp_path.unlink()
 

--- a/tests/test_analyze_uboot.py
+++ b/tests/test_analyze_uboot.py
@@ -311,21 +311,27 @@ class TestUBootGitCommitExtraction:
     def test_extract_git_commit_from_version(self) -> None:
         """Test extracting git commit hash from realistic version string."""
         version = "U-Boot 2017.09-gfd8bfa2acd-dirty #vscode"
-        match = re.search(r"-g([0-9a-f]+)", version)
+        match = re.search(r"-g([0-9a-f]{7,40})(?:-|$|\s)", version)
         assert match is not None
         assert match.group(1) == "fd8bfa2acd"
 
     def test_extract_git_commit_short_hash(self) -> None:
-        """Test extracting shorter git commit hash."""
+        """Test extracting shorter git commit hash (7 chars)."""
         version = "U-Boot 2023.07-gabcdef0"
-        match = re.search(r"-g([0-9a-f]+)", version)
+        match = re.search(r"-g([0-9a-f]{7,40})(?:-|$|\s)", version)
         assert match is not None
         assert match.group(1) == "abcdef0"
 
     def test_no_git_commit_in_version(self) -> None:
         """Test version string without git commit."""
         version = "U-Boot 2023.07"
-        match = re.search(r"-g([0-9a-f]+)", version)
+        match = re.search(r"-g([0-9a-f]{7,40})(?:-|$|\s)", version)
+        assert match is None
+
+    def test_git_commit_rejects_short_hex(self) -> None:
+        """Test that very short hex strings after -g are rejected."""
+        version = "U-Boot 2023.07-ga1b"
+        match = re.search(r"-g([0-9a-f]{7,40})(?:-|$|\s)", version)
         assert match is None
 
     def test_git_commit_field_in_analysis(self) -> None:
@@ -370,21 +376,28 @@ class TestUBootBuildDateExtraction:
     def test_parse_build_date_from_parenthesized(self) -> None:
         """Test parsing build date from parenthesized format."""
         build_date = "(Nov 27 2025 - 08:06:12 +0000)"
-        match = re.match(r"\((\w+ \d+ \d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
+        match = re.match(r"\((\w+\s+\d+\s+\d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
         assert match is not None
         assert match.group(1) == "Nov 27 2025 - 08:06:12 +0000"
 
     def test_parse_build_date_different_timezone(self) -> None:
         """Test parsing build date with non-zero timezone."""
         build_date = "(Dec 15 2023 - 10:30:00 -0500)"
-        match = re.match(r"\((\w+ \d+ \d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
+        match = re.match(r"\((\w+\s+\d+\s+\d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
         assert match is not None
         assert match.group(1) == "Dec 15 2023 - 10:30:00 -0500"
+
+    def test_parse_build_date_space_padded_day(self) -> None:
+        """Test parsing build date with space-padded single-digit day (GCC __DATE__)."""
+        build_date = "(Jun  3 2025 - 08:06:12 +0000)"
+        match = re.match(r"\((\w+\s+\d+\s+\d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
+        assert match is not None
+        assert match.group(1) == "Jun  3 2025 - 08:06:12 +0000"
 
     def test_no_match_without_parentheses(self) -> None:
         """Test that non-parenthesized date strings don't match."""
         build_date = "Nov 27 2025 - 08:06:12 +0000"
-        match = re.match(r"\((\w+ \d+ \d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
+        match = re.match(r"\((\w+\s+\d+\s+\d{4} - \d{2}:\d{2}:\d{2} [+-]\d{4})\)", build_date)
         assert match is None
 
     def test_build_date_field_in_analysis(self) -> None:


### PR DESCRIPTION
## Summary
- Add `firmware_sha256` field to binwalk analysis (chunked hashing for memory efficiency)
- Add `uboot_build_date` and `uboot_git_commit` fields to U-Boot analysis
- Tighten git commit regex to require 7-40 hex chars
- Fix build date regex for space-padded days (e.g., `Jun  3`)

Closes #108

## Test plan
- [x] 752 tests pass (includes new tests for chunked SHA256, git commit validation, space-padded dates)
- [x] Code reviewed by Opus (APPROVE with warnings addressed)
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)