### PR TITLE
feat: Add rootfs core metadata fields (#109)

### DIFF
--- a/scripts/analyze_rootfs.py
+++ b/scripts/analyze_rootfs.py
@@ -159,17 +159,20 @@ def parse_os_release(rootfs: Path, analysis: RootfsAnalysis) -> None:
                 version_value = line.split("=", 1)[1].strip('"')
                 analysis.os_version = version_value
                 analysis.add_metadata("os_version", "/etc/os-release", "VERSION field")
-                analysis.buildroot_version = version_value
-                analysis.add_metadata(
-                    "buildroot_version",
-                    "/etc/os-release",
-                    "VERSION field (Buildroot version with git commit)",
-                )
             elif line.startswith("PRETTY_NAME="):
                 analysis.os_pretty_name = line.split("=", 1)[1].strip('"')
                 analysis.add_metadata("os_pretty_name", "/etc/os-release", "PRETTY_NAME field")
     except Exception as e:
         warn(f"Failed to parse /etc/os-release: {e}")
+
+    # Set buildroot_version only when OS is actually Buildroot
+    if analysis.os_name and analysis.os_name.lower() == "buildroot" and analysis.os_version:
+        analysis.buildroot_version = analysis.os_version
+        analysis.add_metadata(
+            "buildroot_version",
+            "/etc/os-release",
+            "VERSION field (set only when NAME=Buildroot)",
+        )
 
 
 def extract_kernel_version(rootfs: Path, analysis: RootfsAnalysis) -> None:
@@ -284,8 +287,8 @@ def analyze_busybox(rootfs: Path, analysis: RootfsAnalysis) -> None:
                     "/bin/busybox",
                     "strings /bin/busybox | grep 'BusyBox v'",
                 )
-                # Extract build date from parentheses
-                date_match = re.search(r"\(([^)]+)\)", line)
+                # Extract build date from parentheses (validate it looks like a date)
+                date_match = re.search(r"\((\d{4}-\d{2}-\d{2}\s[^)]+)\)", line)
                 if date_match:
                     analysis.busybox_build_date = date_match.group(1)
                     analysis.add_metadata(

--- a/tests/test_analyze_rootfs.py
+++ b/tests/test_analyze_rootfs.py
@@ -410,7 +410,22 @@ class TestParseOsRelease:
 
         assert analysis.buildroot_version == "2018.02-rc3-gd56bbacb"
         assert analysis._source["buildroot_version"] == "/etc/os-release"
-        assert "Buildroot version" in analysis._method["buildroot_version"]
+        assert "Buildroot" in analysis._method["buildroot_version"]
+
+    def test_parse_os_release_non_buildroot_skips_buildroot_version(self, tmp_path: Path) -> None:
+        """Test that buildroot_version is not set for non-Buildroot OS."""
+        rootfs = tmp_path / "rootfs"
+        etc_dir = rootfs / "etc"
+        etc_dir.mkdir(parents=True)
+
+        os_release = etc_dir / "os-release"
+        os_release.write_text('NAME="OpenWrt"\nVERSION="23.05.0"\n')
+
+        analysis = RootfsAnalysis(firmware_file="test.img", rootfs_path=str(rootfs))
+        parse_os_release(rootfs, analysis)
+
+        assert analysis.os_version == "23.05.0"
+        assert analysis.buildroot_version is None
 
     def test_parse_os_release_missing_file(self, tmp_path: Path) -> None:
         """Test parsing when /etc/os-release doesn't exist."""
@@ -642,6 +657,24 @@ class TestAnalyzeBusybox:
 
         assert analysis.busybox_build_date == "2025-11-27 08:14:38 UTC"
         assert analysis._source["busybox_build_date"] == "/bin/busybox"
+
+    @patch("subprocess.run")
+    def test_analyze_busybox_non_date_parens_skipped(self, mock_run: Any, tmp_path: Path) -> None:
+        """Test that non-date parenthesized content is not captured as build date."""
+        rootfs = tmp_path / "rootfs"
+        bin_dir = rootfs / "bin"
+        bin_dir.mkdir(parents=True)
+
+        busybox = bin_dir / "busybox"
+        busybox.write_bytes(b"dummy binary")
+
+        mock_run.return_value = MagicMock(stdout="BusyBox v1.27.2 (compiled by GCC)\n")
+
+        analysis = RootfsAnalysis(firmware_file="test.img", rootfs_path=str(rootfs))
+        analyze_busybox(rootfs, analysis)
+
+        assert analysis.busybox_found is True
+        assert analysis.busybox_build_date is None
 
     def test_analyze_busybox_not_found(self, tmp_path: Path) -> None:
         """Test analyzing when BusyBox doesn't exist."""


### PR DESCRIPTION
## Summary
- Add `kernel_vermagic`, `busybox_build_date`, `buildroot_version` fields to rootfs analysis
- Guard `buildroot_version` to only set when OS NAME is actually "Buildroot"
- Tighten BusyBox date regex to validate date format (YYYY-MM-DD)

Closes #109

## Test plan
- [x] 752 tests pass (includes new tests for non-Buildroot OS, non-date parenthesized content)
- [x] Code reviewed by Opus (APPROVE with warnings addressed)
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)