### PR TITLE
feat: Add boot process hardware specs and partition completeness (#111)

### DIFF
--- a/scripts/analyze_boot_process.py
+++ b/scripts/analyze_boot_process.py
@@ -18,6 +18,7 @@ Arguments:
 """
 
 import re
+import struct
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -37,6 +38,10 @@ MIN_FIT_IMAGES_FOR_AB = 2
 
 # FIT info extraction limit
 FIT_INFO_LINE_LIMIT = 30
+
+# Rockchip parameter file constants
+RKFW_PARAM_OFFSET_POS = 0x22
+RKFW_PARAM_MAX_SIZE = 65536
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,6 +97,11 @@ class BootProcessAnalysis(AnalysisBase):
 
     firmware_file: str
     firmware_size: int
+    soc_name: str | None = None
+    cpu_architecture: str | None = None
+    storage_type: str | None = None
+    console_device: str | None = None
+    console_baudrate: str | None = None
     hardware_properties: list[HardwareProperty] = field(default_factory=list)
     boot_components: list[BootComponent] = field(default_factory=list)
     component_versions: list[ComponentVersion] = field(default_factory=list)
@@ -172,6 +182,203 @@ def load_firmware_offsets(output_dir: Path) -> dict[str, str | int]:
         sys.exit(1)
 
 
+def extract_rockchip_parameter(firmware_path: Path) -> str | None:
+    """Extract the Rockchip parameter file from RKFW firmware image.
+
+    The RKFW format embeds a parameter file at an offset specified in the
+    firmware header. The parameter file contains partition layout definitions
+    in CMDLINE format.
+
+    Args:
+        firmware_path: Path to firmware image
+
+    Returns:
+        Parameter file contents as string, or None if extraction fails
+    """
+    try:
+        with firmware_path.open("rb") as f:
+            # Read RKFW magic
+            magic = f.read(4)
+            if magic != b"RKFW":
+                return None
+
+            # Read parameter offset from header (little-endian uint32 at 0x22)
+            f.seek(RKFW_PARAM_OFFSET_POS)
+            param_offset = struct.unpack("<I", f.read(4))[0]
+
+            # Read parameter section header (4 bytes magic + 4 bytes size)
+            f.seek(param_offset)
+            param_magic = f.read(4)
+            if param_magic != b"PARM":
+                return None
+
+            param_size = struct.unpack("<I", f.read(4))[0]
+            if param_size > RKFW_PARAM_MAX_SIZE:
+                # Sanity check: parameter files are typically < 1KB
+                return None
+
+            # Read parameter content
+            param_data = f.read(param_size)
+            return param_data.decode("utf-8", errors="replace")
+    except (OSError, struct.error, ValueError) as e:
+        warn(f"Failed to extract Rockchip parameter file: {e}")
+        return None
+
+
+def parse_rockchip_partitions(param_content: str) -> list[Partition]:
+    """Parse partition definitions from Rockchip parameter file content.
+
+    The parameter file uses CMDLINE format with mtdparts/blkdevparts syntax:
+    CMDLINE:mtdparts=rk29xxnand:0x2000@0x2000(uboot),...
+
+    Args:
+        param_content: Raw parameter file text
+
+    Returns:
+        List of Partition objects parsed from parameter file
+    """
+    partitions: list[Partition] = []
+
+    # Find CMDLINE line containing partition definitions
+    for raw_line in param_content.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("CMDLINE:"):
+            continue
+
+        # Extract mtdparts or blkdevparts definition
+        parts_match = re.search(r"(?:mtdparts|blkdevparts)=[^:]+:(.*?)(?:\s|$)", line)
+        if not parts_match:
+            continue
+
+        parts_str = parts_match.group(1)
+        # Parse each partition: size@offset(name)
+        for part_match in re.finditer(r"(0x[0-9a-fA-F]+|-)@(0x[0-9a-fA-F]+)\(([^)]+)\)", parts_str):
+            size_str = part_match.group(1)
+            offset_str = part_match.group(2)
+
+            # Convert size from 512-byte sectors to MB
+            if size_str == "-":
+                size_mb = 0  # Remaining space
+            else:
+                size_sectors = int(size_str, 16)
+                size_mb = (size_sectors * 512) // (1024 * 1024)
+
+            name = part_match.group(3)
+
+            # Determine partition type and content from name
+            ptype, content = _classify_partition(name)
+
+            partitions.append(
+                Partition(
+                    region=name,
+                    offset=offset_str,
+                    size_mb=size_mb,
+                    type=ptype,
+                    content=content,
+                )
+            )
+
+    return partitions
+
+
+def _classify_partition(name: str) -> tuple[str, str]:
+    """Classify a partition by name into type and content description.
+
+    Args:
+        name: Partition name from parameter file
+
+    Returns:
+        Tuple of (type, content description)
+    """
+    classifications: dict[str, tuple[str, str]] = {
+        "uboot": ("raw", "U-Boot bootloader"),
+        "trust": ("raw", "OP-TEE / Trusted firmware"),
+        "misc": ("raw", "Boot control / recovery flags"),
+        "dtb": ("raw", "Device tree blob"),
+        "dtbo": ("raw", "Device tree overlay"),
+        "boot": ("FIT/raw", "Kernel + ramdisk"),
+        "recovery": ("FIT/raw", "Recovery kernel + ramdisk"),
+        "rootfs": ("SquashFS", "Main filesystem"),
+        "oem": ("ext4", "OEM data partition"),
+        "userdata": ("ext4", "User data partition"),
+        "reserved": ("raw", "Reserved space"),
+    }
+
+    # Try exact match first
+    if name in classifications:
+        return classifications[name]
+
+    # Try prefix match (e.g., dtb1, dtb2)
+    for prefix, (ptype, content) in classifications.items():
+        if name.startswith(prefix):
+            return ptype, content
+
+    return "unknown", name
+
+
+def analyze_storage_type(analysis: BootProcessAnalysis, dts_file: Path | None) -> None:
+    """Determine storage type from bootargs or device tree.
+
+    Looks for eMMC/SD card evidence in kernel command line (root=/dev/mmcblk)
+    or DTS mmc/emmc/dwmmc nodes.
+
+    Args:
+        analysis: Analysis object to update
+        dts_file: Path to device tree source file (may be None)
+    """
+    # Check kernel command line for mmcblk references
+    if analysis.kernel_cmdline and "mmcblk" in analysis.kernel_cmdline:
+        analysis.storage_type = "eMMC"
+        analysis.add_metadata(
+            "storage_type",
+            "kernel-cmdline",
+            "bootargs contains mmcblk reference indicating eMMC/MMC storage",
+        )
+        return
+
+    # Check DTS for eMMC/MMC controller nodes
+    if dts_file and dts_file.exists():
+        try:
+            content = dts_file.read_text()
+            if re.search(r"(?:emmc|mmc-hs[24]00|sdhci)", content, re.IGNORECASE):
+                analysis.storage_type = "eMMC"
+                analysis.add_metadata(
+                    "storage_type",
+                    "device-tree",
+                    "DTS contains eMMC/SDHCI controller nodes",
+                )
+                return
+        except (OSError, ValueError):
+            pass
+
+    # Check U-Boot environment for mmc references
+    if analysis.kernel_cmdline and "mmc" in analysis.kernel_cmdline.lower():
+        analysis.storage_type = "eMMC"
+        analysis.add_metadata(
+            "storage_type",
+            "kernel-cmdline",
+            "bootargs contains mmc reference",
+        )
+
+
+def _analyze_partitions_from_firmware(
+    firmware: Path, offsets: dict[str, str | int], analysis: BootProcessAnalysis
+) -> None:
+    """Try Rockchip parameter file first, fall back to offset-based partitions."""
+    param_content = extract_rockchip_parameter(firmware)
+    if param_content:
+        param_partitions = parse_rockchip_partitions(param_content)
+        if param_partitions:
+            analysis.partitions.extend(param_partitions)
+            analysis.add_metadata(
+                "partitions",
+                "rockchip-parameter-file",
+                "parse CMDLINE mtdparts from RKFW parameter section",
+            )
+    if not analysis.partitions:
+        analyze_partitions(offsets, analysis)
+
+
 def analyze_boot_process(
     firmware_path: str, extract_dir: Path, offsets: dict[str, str | int]
 ) -> BootProcessAnalysis:
@@ -244,15 +451,16 @@ def analyze_boot_process(
     # Analyze component versions
     analyze_component_versions(firmware, extract_dir, analysis)
 
-    # Analyze partition layout
-    analyze_partitions(offsets, analysis)
+    # Analyze partition layout (try Rockchip parameter file first, fall back to offsets)
+    _analyze_partitions_from_firmware(firmware, offsets, analysis)
 
     # Analyze A/B redundancy
     analyze_ab_redundancy(extract_dir, analysis)
 
-    # Analyze boot configuration
+    # Analyze boot configuration and storage type
     if kernel_full_dts:
         analyze_boot_config(kernel_full_dts, analysis)
+    analyze_storage_type(analysis, kernel_full_dts)
 
     return analysis
 
@@ -285,10 +493,15 @@ def analyze_hardware_properties(
 
             # Derive SoC from compatible string
             if "rv1126" in compat:
+                soc_value = "Rockchip RV1126"
                 analysis.hardware_properties.append(
-                    HardwareProperty(
-                        property="SoC", value="Rockchip RV1126", source="DTS compatible"
-                    )
+                    HardwareProperty(property="SoC", value=soc_value, source="DTS compatible")
+                )
+                analysis.soc_name = soc_value
+                analysis.add_metadata(
+                    "soc_name",
+                    "device-tree",
+                    "derived from DTS compatible string containing rv1126",
                 )
 
         # Derive architecture from ELF binaries in rootfs
@@ -309,6 +522,19 @@ def analyze_hardware_properties(
                             HardwareProperty(
                                 property="Architecture", value=arch, source="ELF header"
                             )
+                        )
+                        # Set top-level cpu_architecture field
+                        if arch == "ARM":
+                            cpu_arch = "ARM Cortex-A7 (32-bit)"
+                        elif arch == "aarch64":
+                            cpu_arch = "ARM (64-bit)"
+                        else:
+                            cpu_arch = arch
+                        analysis.cpu_architecture = cpu_arch
+                        analysis.add_metadata(
+                            "cpu_architecture",
+                            "ELF-header",
+                            f"file command on {elf_sample.name} reports {arch}",
                         )
                         break
                 except (OSError, subprocess.SubprocessError):
@@ -610,10 +836,25 @@ def analyze_boot_config(dts_file: Path, analysis: BootProcessAnalysis) -> None:
                     parameter="Baud Rate", value=str(baudrate), source="DTS rockchip,baudrate"
                 )
             )
+            analysis.console_baudrate = str(baudrate)
+            analysis.add_metadata(
+                "console_baudrate",
+                "device-tree",
+                "rockchip,baudrate property in DTS",
+            )
 
         if console:
             analysis.console_configs.append(
                 ConsoleConfig(parameter="Console", value=console, source="DTS stdout-path/bootargs")
+            )
+            # Extract just the device name (e.g., "ttyFIQ0" from "ttyFIQ0,1500000n8"
+            # or "serial0" from "serial0:1500000n8")
+            console_dev = re.split(r"[,:]", console)[0]
+            analysis.console_device = console_dev
+            analysis.add_metadata(
+                "console_device",
+                "device-tree",
+                "stdout-path or bootargs console= in DTS",
             )
 
     except (OSError, ValueError) as e:
@@ -778,6 +1019,11 @@ def generate_markdown(analysis: BootProcessAnalysis, output_file: Path) -> None:
 SIMPLE_FIELDS = [
     "firmware_file",
     "firmware_size",
+    "soc_name",
+    "cpu_architecture",
+    "storage_type",
+    "console_device",
+    "console_baudrate",
     "bootloader_fit_info",
     "kernel_fit_info",
     "ab_redundancy",

--- a/tests/test_analyze_boot_process.py
+++ b/tests/test_analyze_boot_process.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import struct
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,16 +23,20 @@ from analyze_boot_process import (
     ConsoleConfig,
     HardwareProperty,
     Partition,
+    _classify_partition,
     analyze_ab_redundancy,
     analyze_boot_components,
     analyze_boot_config,
     analyze_component_versions,
     analyze_hardware_properties,
     analyze_partitions,
+    analyze_storage_type,
+    extract_rockchip_parameter,
     find_largest_dts,
     find_rootfs,
     get_fit_info,
     load_firmware_offsets,
+    parse_rockchip_partitions,
 )
 from lib.output import output_toml
 
@@ -1794,3 +1799,378 @@ class TestIntegration:
         assert parsed["firmware_size"] == 1024
         # ab_redundancy defaults to False, so it will be included
         assert parsed["ab_redundancy"] is False
+
+
+class TestNewHardwareSpecFields:
+    """Test the 5 new hardware spec scalar fields."""
+
+    def test_new_fields_default_none(self) -> None:
+        """Test that new fields default to None."""
+        analysis = BootProcessAnalysis(
+            firmware_file="test.img",
+            firmware_size=1024,
+        )
+        assert analysis.soc_name is None
+        assert analysis.cpu_architecture is None
+        assert analysis.storage_type is None
+        assert analysis.console_device is None
+        assert analysis.console_baudrate is None
+
+    def test_new_fields_in_simple_fields(self) -> None:
+        """Test that new fields are in SIMPLE_FIELDS for TOML output."""
+        assert "soc_name" in SIMPLE_FIELDS
+        assert "cpu_architecture" in SIMPLE_FIELDS
+        assert "storage_type" in SIMPLE_FIELDS
+        assert "console_device" in SIMPLE_FIELDS
+        assert "console_baudrate" in SIMPLE_FIELDS
+
+    def test_soc_name_populated_from_dts(self, tmp_path: Path) -> None:
+        """Test that soc_name is set when DTS contains rv1126."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            compatible = "rockchip,rv1126-evb", "rockchip,rv1126";
+        };
+        """)
+
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analyze_hardware_properties(dts_file, analysis, extract_dir)
+
+        assert analysis.soc_name == "Rockchip RV1126"
+        assert "soc_name" in analysis._source
+        assert analysis._source["soc_name"] == "device-tree"
+
+    @patch("subprocess.run")
+    def test_cpu_architecture_populated_from_elf(self, mock_run: Any, tmp_path: Path) -> None:
+        """Test that cpu_architecture is set from ELF header."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("/ { };")
+
+        extract_dir = tmp_path / "extract"
+        squashfs_root = extract_dir / "squashfs-root"
+        bin_dir = squashfs_root / "bin"
+        bin_dir.mkdir(parents=True)
+
+        executable = bin_dir / "busybox"
+        executable.write_bytes(b"dummy")
+        executable.chmod(0o755)
+
+        mock_run.return_value = MagicMock(stdout="ELF 32-bit LSB executable, ARM, version 1")
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analyze_hardware_properties(dts_file, analysis, extract_dir)
+
+        assert analysis.cpu_architecture == "ARM Cortex-A7 (32-bit)"
+        assert "cpu_architecture" in analysis._source
+        assert analysis._source["cpu_architecture"] == "ELF-header"
+
+    def test_console_baudrate_populated(self, tmp_path: Path) -> None:
+        """Test that console_baudrate is set from DTS."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            rockchip,baudrate = <1500000>;
+        };
+        """)
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analyze_boot_config(dts_file, analysis)
+
+        assert analysis.console_baudrate == "1500000"
+        assert "console_baudrate" in analysis._source
+
+    def test_console_device_populated_from_stdout_path(self, tmp_path: Path) -> None:
+        """Test that console_device is set from stdout-path."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            stdout-path = "serial0:1500000n8";
+        };
+        """)
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analyze_boot_config(dts_file, analysis)
+
+        assert analysis.console_device == "serial0"
+        assert "console_device" in analysis._source
+
+    def test_console_device_populated_from_bootargs(self, tmp_path: Path) -> None:
+        """Test that console_device is set from bootargs console=."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            bootargs = "console=ttyFIQ0,1500000 root=/dev/mmcblk0p5";
+        };
+        """)
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analyze_boot_config(dts_file, analysis)
+
+        assert analysis.console_device == "ttyFIQ0"
+
+    def test_new_fields_in_toml_output(self) -> None:
+        """Test that new fields appear in TOML output."""
+        analysis = BootProcessAnalysis(
+            firmware_file="test.img",
+            firmware_size=1024,
+            soc_name="Rockchip RV1126",
+            cpu_architecture="ARM Cortex-A7 (32-bit)",
+            storage_type="eMMC",
+            console_device="ttyFIQ0",
+            console_baudrate="1500000",
+        )
+
+        toml_str = output_toml(
+            analysis,
+            title="Boot process and partition layout analysis",
+            simple_fields=SIMPLE_FIELDS,
+            complex_fields=COMPLEX_FIELDS,
+        )
+        parsed = tomlkit.loads(toml_str)
+
+        assert parsed["soc_name"] == "Rockchip RV1126"
+        assert parsed["cpu_architecture"] == "ARM Cortex-A7 (32-bit)"
+        assert parsed["storage_type"] == "eMMC"
+        assert parsed["console_device"] == "ttyFIQ0"
+        assert parsed["console_baudrate"] == "1500000"
+
+    def test_new_fields_excluded_when_none(self) -> None:
+        """Test that None fields are excluded from TOML output."""
+        analysis = BootProcessAnalysis(
+            firmware_file="test.img",
+            firmware_size=1024,
+        )
+
+        toml_str = output_toml(
+            analysis,
+            title="Boot process and partition layout analysis",
+            simple_fields=SIMPLE_FIELDS,
+            complex_fields=COMPLEX_FIELDS,
+        )
+
+        assert "soc_name" not in toml_str
+        assert "cpu_architecture" not in toml_str
+        assert "storage_type" not in toml_str
+        assert "console_device" not in toml_str
+        assert "console_baudrate" not in toml_str
+
+
+class TestExtractRockchipParameter:
+    """Test extract_rockchip_parameter function."""
+
+    def test_extract_from_rkfw_firmware(self, tmp_path: Path) -> None:
+        """Test extracting parameter from valid RKFW firmware."""
+
+        firmware = tmp_path / "firmware.img"
+
+        # Build a minimal RKFW image with parameter section
+        param_content = b"FIRMWARE_VER:1.0\nCMDLINE:mtdparts=rk29xxnand:0x2000@0x4000(uboot)\n"
+        param_offset = 0x100  # Place PARM section at offset 0x100
+
+        # Build header: RKFW magic + padding to 0x22 + param_offset
+        header = b"RKFW" + b"\x00" * (0x22 - 4)
+        header += struct.pack("<I", param_offset)
+        header += b"\x00" * (param_offset - len(header))
+
+        # Build PARM section
+        parm_section = b"PARM" + struct.pack("<I", len(param_content)) + param_content
+
+        firmware.write_bytes(header + parm_section)
+
+        result = extract_rockchip_parameter(firmware)
+        assert result is not None
+        assert "FIRMWARE_VER" in result
+
+    def test_extract_non_rkfw_returns_none(self, tmp_path: Path) -> None:
+        """Test that non-RKFW firmware returns None."""
+        firmware = tmp_path / "firmware.img"
+        firmware.write_bytes(b"NOTRKFW" + b"\x00" * 256)
+
+        result = extract_rockchip_parameter(firmware)
+        assert result is None
+
+    def test_extract_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Test that missing firmware file returns None."""
+        firmware = tmp_path / "nonexistent.img"
+
+        result = extract_rockchip_parameter(firmware)
+        assert result is None
+
+    def test_extract_truncated_file_returns_none(self, tmp_path: Path) -> None:
+        """Test that truncated firmware returns None."""
+        firmware = tmp_path / "firmware.img"
+        firmware.write_bytes(b"RKFW")  # Too short to read offset
+
+        result = extract_rockchip_parameter(firmware)
+        assert result is None
+
+
+class TestParseRockchipPartitions:
+    """Test parse_rockchip_partitions function."""
+
+    def test_parse_standard_parameter_file(self) -> None:
+        """Test parsing a standard Rockchip parameter file."""
+        param_content = (
+            "FIRMWARE_VER:8.1\n"
+            "MACHINE_MODEL:RK3399\n"
+            "CMDLINE:mtdparts=rk29xxnand:0x00002000@0x00004000(uboot),"
+            "0x00002000@0x00006000(trust),"
+            "0x00002000@0x00008000(misc),"
+            "0x00010000@0x0000a000(boot),"
+            "0x00010000@0x0001a000(recovery),"
+            "0x00040000@0x0004a000(oem),"
+            "0x00c00000@0x0008a000(rootfs),"
+            "-@0x00c8a000(userdata)\n"
+        )
+
+        partitions = parse_rockchip_partitions(param_content)
+
+        assert len(partitions) == 8
+
+        # Check first partition
+        assert partitions[0].region == "uboot"
+        assert partitions[0].offset == "0x00004000"
+        assert partitions[0].type == "raw"
+        assert partitions[0].content == "U-Boot bootloader"
+
+        # Check trust partition
+        trust_part = next(p for p in partitions if p.region == "trust")
+        assert trust_part.type == "raw"
+        assert "Trusted firmware" in trust_part.content
+
+        # Check misc partition
+        misc_part = next(p for p in partitions if p.region == "misc")
+        assert misc_part.type == "raw"
+
+        # Check userdata (remaining space)
+        userdata_part = next(p for p in partitions if p.region == "userdata")
+        assert userdata_part.size_mb == 0  # "-" means remaining space
+
+    def test_parse_empty_content(self) -> None:
+        """Test parsing empty content returns empty list."""
+        partitions = parse_rockchip_partitions("")
+        assert partitions == []
+
+    def test_parse_no_cmdline(self) -> None:
+        """Test parsing content without CMDLINE returns empty list."""
+        param_content = "FIRMWARE_VER:1.0\nMACHINE_MODEL:Test\n"
+        partitions = parse_rockchip_partitions(param_content)
+        assert partitions == []
+
+    def test_parse_size_conversion(self) -> None:
+        """Test that partition sizes are correctly converted from sectors to MB."""
+        # 0x800 sectors = 2048 sectors * 512 bytes = 1MB
+        param_content = "CMDLINE:mtdparts=rk29xxnand:0x00000800@0x00000000(test)\n"
+        partitions = parse_rockchip_partitions(param_content)
+
+        assert len(partitions) == 1
+        assert partitions[0].size_mb == 1
+
+    def test_parse_blkdevparts_format(self) -> None:
+        """Test parsing blkdevparts format (alternative to mtdparts)."""
+        param_content = (
+            "CMDLINE:blkdevparts=mmcblk0:"
+            "0x00002000@0x00004000(uboot),"
+            "0x00002000@0x00006000(trust)\n"
+        )
+        partitions = parse_rockchip_partitions(param_content)
+        assert len(partitions) == 2
+
+
+class TestClassifyPartition:
+    """Test _classify_partition function."""
+
+    def test_classify_known_partitions(self) -> None:
+        """Test classification of known partition names."""
+        assert _classify_partition("uboot") == ("raw", "U-Boot bootloader")
+        assert _classify_partition("trust") == ("raw", "OP-TEE / Trusted firmware")
+        assert _classify_partition("misc") == ("raw", "Boot control / recovery flags")
+        assert _classify_partition("boot") == ("FIT/raw", "Kernel + ramdisk")
+        assert _classify_partition("recovery") == ("FIT/raw", "Recovery kernel + ramdisk")
+        assert _classify_partition("rootfs") == ("SquashFS", "Main filesystem")
+        assert _classify_partition("oem") == ("ext4", "OEM data partition")
+        assert _classify_partition("userdata") == ("ext4", "User data partition")
+        assert _classify_partition("reserved") == ("raw", "Reserved space")
+
+    def test_classify_prefix_match(self) -> None:
+        """Test classification by prefix match (e.g., dtb1, dtb2)."""
+        ptype, content = _classify_partition("dtb1")
+        assert ptype == "raw"
+        assert "Device tree" in content
+
+    def test_classify_unknown_partition(self) -> None:
+        """Test classification of unknown partition names."""
+        ptype, content = _classify_partition("custom_part")
+        assert ptype == "unknown"
+        assert content == "custom_part"
+
+
+class TestAnalyzeStorageType:
+    """Test analyze_storage_type function."""
+
+    def test_storage_type_from_mmcblk_in_bootargs(self) -> None:
+        """Test detecting eMMC from mmcblk in bootargs."""
+        analysis = BootProcessAnalysis("test.img", 1024)
+        analysis.kernel_cmdline = "console=ttyFIQ0 root=/dev/mmcblk0p5 rootfstype=squashfs"
+
+        analyze_storage_type(analysis, None)
+
+        assert analysis.storage_type == "eMMC"
+        assert analysis._source["storage_type"] == "kernel-cmdline"
+
+    def test_storage_type_from_dts_emmc(self, tmp_path: Path) -> None:
+        """Test detecting eMMC from DTS emmc nodes."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            emmc@ff390000 {
+                compatible = "rockchip,rk3399-dw-mshc";
+                mmc-hs200-1_8v;
+            };
+        };
+        """)
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+
+        analyze_storage_type(analysis, dts_file)
+
+        assert analysis.storage_type == "eMMC"
+        assert analysis._source["storage_type"] == "device-tree"
+
+    def test_storage_type_from_dts_sdhci(self, tmp_path: Path) -> None:
+        """Test detecting eMMC from DTS sdhci nodes."""
+        dts_file = tmp_path / "system.dtb"
+        dts_file.write_text("""
+        / {
+            sdhci@ff370000 {
+                compatible = "arasan,sdhci-5.1";
+            };
+        };
+        """)
+
+        analysis = BootProcessAnalysis("test.img", 1024)
+
+        analyze_storage_type(analysis, dts_file)
+
+        assert analysis.storage_type == "eMMC"
+
+    def test_storage_type_none_when_no_evidence(self) -> None:
+        """Test that storage_type remains None without evidence."""
+        analysis = BootProcessAnalysis("test.img", 1024)
+
+        analyze_storage_type(analysis, None)
+
+        assert analysis.storage_type is None
+
+    def test_storage_type_handles_missing_dts(self, tmp_path: Path) -> None:
+        """Test storage type handles missing DTS gracefully."""
+        dts_file = tmp_path / "nonexistent.dtb"
+        analysis = BootProcessAnalysis("test.img", 1024)
+
+        # Should not raise
+        analyze_storage_type(analysis, dts_file)
+
+        assert analysis.storage_type is None


### PR DESCRIPTION
## Summary

- Add 5 top-level hardware spec fields to `boot_process.toml`: `soc_name`, `cpu_architecture`, `storage_type`, `console_device`, `console_baudrate`
- Add Rockchip parameter file extraction and partition parsing for complete partition table coverage
- Add storage type detection from bootargs and device tree evidence
- All new fields include source/method metadata for traceability

## Test plan

- [x] 26 new tests across 5 test classes (109 total, up from 83)
- [x] Full suite passes (800 tests)
- [x] Zero linting errors

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)