### PR TITLE
docs: Update compliance status for GL.iNet BSP repo publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **PROJECT PAUSED** — December 2025
 >
-> This project is currently on hold due to other priorities. The initial goal of identifying GPL compliance issues has been **conditionally achieved** - GL.iNet has [agreed](https://forum.gl-inet.com/t/comet-gl-rm1-and-open-source/55955/21) to release source code.
+> This project is currently on hold due to other priorities. The initial goal of identifying GPL compliance issues has been **partially achieved** — GL.iNet has [published](https://github.com/gl-inet/kernel-4.19) [source repositories](https://github.com/gl-inet/buildroot-2018) but they contain only unmodified Rockchip BSP code without RM1-specific configurations, device trees, or build instructions. U-Boot source remains unpublished. See open issues on [kernel-4.19](https://github.com/gl-inet/kernel-4.19/issues/1) and [buildroot-2018](https://github.com/gl-inet/buildroot-2018/issues/1).
 >
 > **Potential Purpose Evolution:** This project may evolve into a pilot for validating agentic ISO 9001 QMS tooling implementation using ARM board reverse engineering as the application domain.
 >
@@ -15,29 +15,29 @@
 
 ---
 
-**GL.iNet ships GPL-licensed software in their Comet KVM device but has not released the required source code.**
+**GL.iNet ships GPL-licensed software in their Comet KVM device. In January 2026, they published kernel and Buildroot repositories, but these contain only unmodified Rockchip BSP code — the RM1-specific modifications, configurations, and build instructions required for GPL compliance have not been released.**
 
 This project analyzes the firmware to document what source code GL.iNet must provide under the GPL license.
 
 ## Key Findings
 
-The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has released source code for only one of them.
+The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has published base Rockchip BSP source for several, but none include the RM1-specific modifications needed for GPL compliance.
 
-| Component | License | Source Released? |
-|-----------|---------|:----------------:|
-| Linux Kernel 4.19.111 | GPL-2.0 | :x: No |
-| U-Boot 2017.09 | GPL-2.0+ | :x: No |
-| BusyBox 1.27.2 | GPL-2.0 | :x: No |
-| GNU Coreutils | GPL-3.0+ | :x: No |
-| bcmdhd WiFi Driver | GPL-2.0 | :x: No |
-| FFmpeg 58.x | LGPL-2.1+ | :x: No |
-| BlueZ 3.18.16 | GPL-2.0+ | :x: No |
-| Janus Gateway 2.0.6 | GPL-3.0 | :x: No |
-| glibc 2.28 | LGPL-2.1+ | :x: No |
-| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No |
-| KVMD Application | GPL-3.0 | :white_check_mark: [Yes](https://github.com/gl-inet/glkvm) |
+| Component | License | Source Released? | Notes |
+|-----------|---------|:---:|---|
+| Linux Kernel 4.19.111 | GPL-2.0 | :x: No | [Base BSP published](https://github.com/gl-inet/kernel-4.19), RM1 config/DTS missing |
+| U-Boot 2017.09 | GPL-2.0+ | :x: No | Not published |
+| BusyBox 1.27.2 | GPL-2.0 | :x: No | In [BSP Buildroot](https://github.com/gl-inet/buildroot-2018), RM1 config missing |
+| GNU Coreutils | GPL-3.0+ | :x: No | In BSP Buildroot, RM1 config missing |
+| bcmdhd WiFi Driver | GPL-2.0 | :x: No | In BSP kernel tree, build config missing |
+| FFmpeg 58.x | LGPL-2.1+ | :x: No | In BSP Buildroot, configure flags missing |
+| BlueZ 3.18.16 | GPL-2.0+ | :x: No | In BSP Buildroot, RM1 config missing |
+| Janus Gateway 2.0.6 | GPL-3.0 | :x: No | In BSP Buildroot, RM1 config missing |
+| glibc 2.28 | LGPL-2.1+ | :x: No | BSP has 2.29; firmware uses 2.28 from external toolchain |
+| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing |
+| KVMD Application | GPL-3.0 | :white_check_mark: [Yes](https://github.com/gl-inet/glkvm) | |
 
-Users have [requested source code on the GL.iNet forum](https://forum.gl-inet.com/t/comet-gl-rm1-and-open-source/55955). As of December 2025, GL.iNet has not provided it.
+Users have [requested source code on the GL.iNet forum](https://forum.gl-inet.com/t/comet-gl-rm1-and-open-source/55955). As of March 2026, GL.iNet has published base Rockchip BSP repositories but has not provided the RM1-specific source code or build configurations needed for compliance.
 
 ## Who Must Provide Source Code?
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has pub
 
 | Component | License | Source Released? | Notes |
 |-----------|---------|:---:|---|
-| Linux Kernel 4.19.111 | GPL-2.0 | :x: No | [Base BSP published](https://github.com/gl-inet/kernel-4.19), RM1 config/DTS missing | <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found -->
+| Linux Kernel 4.19.111 | GPL-2.0 | :x: No | [Base BSP published](https://github.com/gl-inet/kernel-4.19), RM1 config/DTS missing <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found --> |
 | U-Boot 2017.09 | GPL-2.0+ | :x: No | Not published |
 | BusyBox 1.27.2 | GPL-2.0 | :x: No | In [BSP Buildroot](https://github.com/gl-inet/buildroot-2018), RM1 config missing |
 | GNU Coreutils | GPL-3.0+ | :x: No | In BSP Buildroot, RM1 config missing |
@@ -34,7 +34,7 @@ The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has pub
 | BlueZ 3.18.16 | GPL-2.0+ | :x: No | In BSP Buildroot, RM1 config missing |
 | Janus Gateway 2.0.6 | GPL-3.0 | :x: No | In BSP Buildroot, RM1 config missing |
 | glibc 2.28 | LGPL-2.1+ | :x: No | BSP has 2.29; firmware uses 2.28 from external toolchain |
-| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing | <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
+| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found --> |
 | KVMD Application | GPL-3.0 | :white_check_mark: [Yes](https://github.com/gl-inet/glkvm) | |
 
 Users have [requested source code on the GL.iNet forum](https://forum.gl-inet.com/t/comet-gl-rm1-and-open-source/55955). As of March 2026, GL.iNet has published base Rockchip BSP repositories but has not provided the RM1-specific source code or build configurations needed for compliance.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-**GL.iNet ships GPL-licensed software in their Comet KVM device. In January 2026, they published kernel and Buildroot repositories, but these contain only unmodified Rockchip BSP code — the RM1-specific modifications, configurations, and build instructions required for GPL compliance have not been released.**
+**GL.iNet ships GPL-licensed software in their Comet KVM device. In January 2026, they published kernel and Buildroot repositories, but these contain only unmodified Rockchip BSP code — the RM1-specific modifications, configurations, and build instructions required for GPL compliance have not been released.** <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found --> <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
 
 This project analyzes the firmware to document what source code GL.iNet must provide under the GPL license.
 
@@ -25,7 +25,7 @@ The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has pub
 
 | Component | License | Source Released? | Notes |
 |-----------|---------|:---:|---|
-| Linux Kernel 4.19.111 | GPL-2.0 | :x: No | [Base BSP published](https://github.com/gl-inet/kernel-4.19), RM1 config/DTS missing |
+| Linux Kernel 4.19.111 | GPL-2.0 | :x: No | [Base BSP published](https://github.com/gl-inet/kernel-4.19), RM1 config/DTS missing | <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found -->
 | U-Boot 2017.09 | GPL-2.0+ | :x: No | Not published |
 | BusyBox 1.27.2 | GPL-2.0 | :x: No | In [BSP Buildroot](https://github.com/gl-inet/buildroot-2018), RM1 config missing |
 | GNU Coreutils | GPL-3.0+ | :x: No | In BSP Buildroot, RM1 config missing |
@@ -34,7 +34,7 @@ The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has pub
 | BlueZ 3.18.16 | GPL-2.0+ | :x: No | In BSP Buildroot, RM1 config missing |
 | Janus Gateway 2.0.6 | GPL-3.0 | :x: No | In BSP Buildroot, RM1 config missing |
 | glibc 2.28 | LGPL-2.1+ | :x: No | BSP has 2.29; firmware uses 2.28 from external toolchain |
-| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing |
+| Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing | <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
 | KVMD Application | GPL-3.0 | :white_check_mark: [Yes](https://github.com/gl-inet/glkvm) | |
 
 Users have [requested source code on the GL.iNet forum](https://forum.gl-inet.com/t/comet-gl-rm1-and-open-source/55955). As of March 2026, GL.iNet has published base Rockchip BSP repositories but has not provided the RM1-specific source code or build configurations needed for compliance.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Comet (GL-RM1) contains at least 10 GPL-licensed components. GL.iNet has pub
 | FFmpeg 58.x | LGPL-2.1+ | :x: No | In BSP Buildroot, configure flags missing |
 | BlueZ 3.18.16 | GPL-2.0+ | :x: No | In BSP Buildroot, RM1 config missing |
 | Janus Gateway 2.0.6 | GPL-3.0 | :x: No | In BSP Buildroot, RM1 config missing |
-| glibc 2.28 | LGPL-2.1+ | :x: No | BSP has 2.29; firmware uses 2.28 from external toolchain |
+| glibc 2.28 | LGPL-2.1+ | :x: No | Version mismatch: BSP ships 2.29, firmware uses 2.28 (external toolchain) |
 | Buildroot 2018.02-rc3 | GPL-2.0+ | :x: No | [BSP published](https://github.com/gl-inet/buildroot-2018), RM1 defconfig missing <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found --> |
 | KVMD Application | GPL-3.0 | :white_check_mark: [Yes](https://github.com/gl-inet/glkvm) | |
 

--- a/docs/GPL-COMPLIANCE-ANALYSIS.md
+++ b/docs/GPL-COMPLIANCE-ANALYSIS.md
@@ -169,13 +169,13 @@ The following GPL-licensed utilities were identified in the firmware:
 
 | Tool | License | Status |
 |------|---------|--------|
-| bash | GPL-3.0+ | Source not provided |
-| gzip | GPL-3.0+ | Source not provided |
-| tar | GPL-3.0+ | Source not provided |
-| grep | GPL-3.0+ | Source not provided |
-| sed | GPL-3.0+ | Source not provided |
-| awk (gawk) | GPL-3.0+ | Source not provided |
-| vim | Vim License (GPL-compatible) | Source not provided |
+| bash | GPL-3.0+ | Base BSP only, RM1 config missing |
+| gzip | GPL-3.0+ | Base BSP only, RM1 config missing |
+| tar | GPL-3.0+ | Base BSP only, RM1 config missing |
+| grep | GPL-3.0+ | Base BSP only, RM1 config missing |
+| sed | GPL-3.0+ | Base BSP only, RM1 config missing |
+| awk (gawk) | GPL-3.0+ | Base BSP only, RM1 config missing |
+| vim | Vim License (GPL-compatible) | Base BSP only, RM1 config missing |
 
 ### 7. FFmpeg Libraries (LGPL/GPL)
 
@@ -220,7 +220,7 @@ The following libraries are under LGPL, requiring source code for the library (i
 
 **Note:** BlueZ, D-Bus, libmad, and Janus Gateway are GPL-licensed, requiring full source disclosure.
 
-**Source Code Status:** BASE BSP PUBLISHED (except glibc) — BlueZ 5.50 (with 17 Rockchip patches), Janus v0.2.6, and other libraries are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1-specific build configurations are missing. glibc 2.28 is NOT in the BSP (which has 2.29); it likely comes from the external prebuilt toolchain.
+**Source Code Status:** BASE BSP PUBLISHED (except glibc) — BlueZ 5.50 (soname 3.18.16, with 17 Rockchip patches), Janus v0.2.6 (soname 2.0.6), and other libraries are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1-specific build configurations are missing. glibc 2.28 is NOT in the BSP (which has 2.29); it likely comes from the external prebuilt toolchain.
 
 **Required Disclosure:**
 - Source code for all LGPL/GPL libraries
@@ -268,7 +268,7 @@ This repository contains only the userspace KVMD application, which is a derivat
   - Kernel .config used for RM1 build
   - GL.iNet-specific patches or modifications
   - Build instructions
-- **Open issue:** [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1) — Missing GL.inet changes
+- **Open issue:** [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1) — Missing GL.iNet changes
 
 ### Buildroot (gl-inet/buildroot-2018) — January 2026
 - **Contents:** Unmodified Rockchip BSP Buildroot (2018.02-rc3)

--- a/docs/GPL-COMPLIANCE-ANALYSIS.md
+++ b/docs/GPL-COMPLIANCE-ANALYSIS.md
@@ -6,7 +6,7 @@
 
 **GL.iNet has not released complete GPL-required source code for the Comet (GL-RM1).**
 
-The firmware contains Linux kernel 4.19.111, U-Boot 2017.09, BusyBox, and other GPL components. In January 2026, GL.iNet published [kernel](https://github.com/gl-inet/kernel-4.19) and [Buildroot](https://github.com/gl-inet/buildroot-2018) repositories, but these contain only unmodified Rockchip BSP code without RM1-specific modifications or build configurations. See open issues: [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1), [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1). <!-- cite: results/rootfs.toml#kernel_version -->
+The firmware contains Linux kernel 4.19.111, U-Boot 2017.09, BusyBox, and other GPL components. <!-- cite: results/rootfs.toml#kernel_version --> In January 2026, GL.iNet published [kernel](https://github.com/gl-inet/kernel-4.19) and [Buildroot](https://github.com/gl-inet/buildroot-2018) repositories, but these contain only unmodified Rockchip BSP code without RM1-specific modifications or build configurations. <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found --> <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found --> See open issues: [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1), [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1). <!-- cite: results/bsp_repos.toml#kernel_issue_url --> <!-- cite: results/bsp_repos.toml#buildroot_issue_url -->
 
 | Status | Components |
 |--------|------------|
@@ -14,7 +14,7 @@ The firmware contains Linux kernel 4.19.111, U-Boot 2017.09, BusyBox, and other 
 | **Base BSP Only** | Linux kernel, BusyBox, Buildroot, bcmdhd, FFmpeg, BlueZ, Janus, Coreutils |
 | **Released** | KVMD application ([github.com/gl-inet/glkvm](https://github.com/gl-inet/glkvm)) |
 
-**Base BSP Only** means GL.iNet published the unmodified Rockchip SDK source but not the RM1-specific device trees, defconfigs, patches, or build instructions needed to reproduce the shipped firmware.
+**Base BSP Only** means GL.iNet published the unmodified Rockchip SDK source but not the RM1-specific device trees, defconfigs, patches, or build instructions needed to reproduce the shipped firmware. <!-- cite: results/bsp_repos.toml#kernel_is_squashed_import --> <!-- cite: results/bsp_repos.toml#buildroot_is_squashed_import -->
 
 **Firmware:** glkvm-RM1-1.7.2-1128-1764344791.img <!-- cite: results/binwalk.toml#firmware_file -->
 **SHA256:** `6044860b839b7ba74de2ec77b2a0764cd0c16ae27ad0f94deb715429c37e8f19`
@@ -78,7 +78,7 @@ When distributing a product containing copyleft software, the distributor must:
 | **Evidence** | Module vermagic: `4.19.111 SMP preempt mod_unload ARMv7 p2v8` | <!-- cite: results/rootfs.toml#kernel_version -->
 | **Platform** | Rockchip RV1126 (ARM Cortex-A7) |
 
-**Source Code Status:** BASE BSP PUBLISHED — [gl-inet/kernel-4.19](https://github.com/gl-inet/kernel-4.19) contains the Rockchip BSP kernel source (4.19.111), but RM1-specific device tree, kernel .config, and GL.iNet patches are missing.
+**Source Code Status:** BASE BSP PUBLISHED — [gl-inet/kernel-4.19](https://github.com/gl-inet/kernel-4.19) contains the Rockchip BSP kernel source (4.19.111), but RM1-specific device tree, kernel .config, and GL.iNet patches are missing. <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found --> <!-- cite: results/bsp_repos.toml#kernel_rm1_defconfig_found -->
 
 The Linux kernel is the core of the operating system. This specific version (4.19.111) with Rockchip RV1126 support contains: <!-- cite: results/rootfs.toml#kernel_version -->
 - Board-specific device tree modifications
@@ -123,7 +123,7 @@ The `-dirty` suffix indicates modifications were made beyond the tagged release.
 | **Build Date** | 2025-11-27 08:14:38 UTC |
 | **Evidence** | Version string in binary |
 
-**Source Code Status:** BASE BSP PUBLISHED — BusyBox 1.27.2 source and Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but the RM1-specific BusyBox .config is missing.
+**Source Code Status:** BASE BSP PUBLISHED — BusyBox 1.27.2 source and Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but the RM1-specific BusyBox .config is missing. <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
 
 While upstream BusyBox source is available, the specific configuration used to build this binary determines which applets are included. The build configuration must be provided.
 
@@ -140,7 +140,7 @@ While upstream BusyBox source is available, the specific configuration used to b
 | **License** | GPL-3.0+ |
 | **Evidence** | Binary present at `/usr/bin/coreutils` |
 
-**Source Code Status:** BASE BSP PUBLISHED — Coreutils package definition is in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1 Buildroot defconfig confirming package selection is missing.
+**Source Code Status:** BASE BSP PUBLISHED — Coreutils package definition is in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1 Buildroot defconfig confirming package selection is missing. <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
 
 **Required Disclosure:**
 - Source code or reference to upstream version
@@ -155,7 +155,7 @@ While upstream BusyBox source is available, the specific configuration used to b
 | **Location** | `/system/lib/modules/bcmdhd.ko` |
 | **Evidence** | Kernel module in firmware |
 
-**Source Code Status:** BASE BSP PUBLISHED — bcmdhd driver source is in the [BSP kernel tree](https://github.com/gl-inet/kernel-4.19) under `drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/`, but the kernel .config confirming build options is missing.
+**Source Code Status:** BASE BSP PUBLISHED — bcmdhd driver source is in the [BSP kernel tree](https://github.com/gl-inet/kernel-4.19) under `drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/`, but the kernel .config confirming build options is missing. <!-- cite: results/bsp_repos.toml#kernel_rm1_defconfig_found -->
 
 This is a Broadcom wireless driver that must be distributed with source code when included in a GPL kernel.
 
@@ -187,7 +187,7 @@ The following GPL-licensed utilities were identified in the firmware:
 | libavdevice | 58.5.100 | LGPL-2.1+ |
 | libavutil | 56.22.100 | LGPL-2.1+ |
 
-**Source Code Status:** BASE BSP PUBLISHED — FFmpeg 4.1.3 source and 20 Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but configure flags and any GL.iNet-specific patches are missing.
+**Source Code Status:** BASE BSP PUBLISHED — FFmpeg 4.1.3 source and 20 Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but configure flags and any GL.iNet-specific patches are missing. <!-- cite: results/bsp_repos.toml#buildroot_glinet_files_found -->
 
 FFmpeg's license depends on build configuration. If built with `--enable-gpl` or linked against GPL libraries (e.g., x264), the entire binary is GPL. Source must be provided either way.
 
@@ -220,7 +220,7 @@ The following libraries are under LGPL, requiring source code for the library (i
 
 **Note:** BlueZ, D-Bus, libmad, and Janus Gateway are GPL-licensed, requiring full source disclosure.
 
-**Source Code Status:** BASE BSP PUBLISHED (except glibc) — BlueZ 5.50 (soname 3.18.16, with 17 Rockchip patches), Janus v0.2.6 (soname 2.0.6), and other libraries are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1-specific build configurations are missing. glibc 2.28 is NOT in the BSP (which has 2.29); it likely comes from the external prebuilt toolchain.
+**Source Code Status:** BASE BSP PUBLISHED (except glibc) — BlueZ 5.50 (soname 3.18.16, with 17 Rockchip patches), Janus v0.2.6 (soname 2.0.6), and other libraries are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1-specific build configurations are missing. <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found --> glibc 2.28 is NOT in the BSP (which has 2.29); it likely comes from the external prebuilt toolchain.
 
 **Required Disclosure:**
 - Source code for all LGPL/GPL libraries
@@ -237,7 +237,7 @@ The following libraries are under LGPL, requiring source code for the library (i
 | **Buildroot Commit** | gd56bbacb |
 | **SDK Base** | Rockchip RV1126/RV1109 Linux SDK |
 
-The firmware is built using Buildroot, which is itself GPL-licensed. GL.iNet has [published the Buildroot source](https://github.com/gl-inet/buildroot-2018), but it contains only the unmodified Rockchip BSP (commit `a439fb32`). The complete Buildroot configuration needed to reproduce the RM1 firmware, including:
+The firmware is built using Buildroot, which is itself GPL-licensed. GL.iNet has [published the Buildroot source](https://github.com/gl-inet/buildroot-2018), but it contains only the unmodified Rockchip BSP (squashed from BSP commit `a439fb32`). <!-- cite: results/bsp_repos.toml#buildroot_bsp_reference_commit --> The complete Buildroot configuration needed to reproduce the RM1 firmware, including:
 - RM1-specific defconfig (e.g., `configs/rockchip_rv1126_glrm1_defconfig`)
 - Package selections and overrides
 - Board overlay directory
@@ -260,26 +260,28 @@ GL.iNet has released the following on GitHub:
 This repository contains only the userspace KVMD application, which is a derivative of the PiKVM project.
 
 ### Kernel Source (gl-inet/kernel-4.19) — January 2026
-- **Contents:** Unmodified Rockchip RV1126 BSP kernel tree (4.19.111)
+- **Contents:** Unmodified Rockchip RV1126 BSP kernel tree (4.19.111) <!-- cite: results/bsp_repos.toml#kernel_repo_url -->
 - **URL:** https://github.com/gl-inet/kernel-4.19
-- **Verified as:** 1:1 match with Rockchip BSP commit `cc9228323509bf2bd59ed73ade9dd3276c97549c`
-- **Missing for RM1 compliance:**
+- **Commit:** `fc316e95` by GL.iNet (`xiaojiang2017`), squashed Rockchip BSP into single "first commit" <!-- cite: results/bsp_repos.toml#kernel_head_commit -->
+- **BSP reference:** Content based on Rockchip BSP commit `cc9228323509bf2bd59ed73ade9dd3276c97549c` ([diff](https://gist.github.com/samueldr/b68142df0b7843263294e913fee4f037)) <!-- cite: results/bsp_repos.toml#kernel_bsp_reference_commit -->
+- **Missing for RM1 compliance:** <!-- cite: results/bsp_repos.toml#kernel_rm1_dts_found -->
   - RM1 device tree (firmware ships `model = "rm1"`, no matching DTS in repo)
-  - Kernel .config used for RM1 build
-  - GL.iNet-specific patches or modifications
+  - Kernel .config used for RM1 build (repo has only `rv1126_defconfig` and `rv1126_robot_defconfig`) <!-- cite: results/bsp_repos.toml#kernel_rv1126_defconfigs -->
+  - GL.iNet-specific patches or modifications (zero GL.iNet files found in tree) <!-- cite: results/bsp_repos.toml#kernel_glinet_files_found -->
   - Build instructions
-- **Open issue:** [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1) — Missing GL.iNet changes
+- **Open issue:** [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1) — Missing GL.iNet changes <!-- cite: results/bsp_repos.toml#kernel_issue_url -->
 
 ### Buildroot (gl-inet/buildroot-2018) — January 2026
-- **Contents:** Unmodified Rockchip BSP Buildroot (2018.02-rc3)
+- **Contents:** Unmodified Rockchip BSP Buildroot (2018.02-rc3) <!-- cite: results/bsp_repos.toml#buildroot_repo_url -->
 - **URL:** https://github.com/gl-inet/buildroot-2018
-- **Verified as:** 1:1 match with Rockchip BSP commit `a439fb32a06a78a2283aa03e32cabb6e531e73bd`
-- **Missing for RM1 compliance:**
-  - RM1 Buildroot defconfig (none of the 30 existing defconfigs target the RM1)
-  - Board overlay directory (`board/rockchip/` referenced by defconfigs is absent)
-  - Any GL.iNet/RM1-specific packages or patches
+- **Commit:** `4a4f065a` by GL.iNet (`xiaojiang2017`), squashed Rockchip BSP into single "first commit" <!-- cite: results/bsp_repos.toml#buildroot_head_commit -->
+- **BSP reference:** Content based on Rockchip BSP commit `a439fb32a06a78a2283aa03e32cabb6e531e73bd` <!-- cite: results/bsp_repos.toml#buildroot_bsp_reference_commit -->
+- **Missing for RM1 compliance:** <!-- cite: results/bsp_repos.toml#buildroot_rm1_defconfig_found -->
+  - RM1 Buildroot defconfig (30 existing RV1126 defconfigs target only generic Rockchip reference boards) <!-- cite: results/bsp_repos.toml#buildroot_rv1126_defconfigs -->
+  - Board overlay directory (`board/rockchip/` referenced by defconfigs is absent) <!-- cite: results/bsp_repos.toml#buildroot_board_overlay_present -->
+  - Any GL.iNet/RM1-specific packages or patches (zero GL.iNet files found in tree) <!-- cite: results/bsp_repos.toml#buildroot_glinet_files_found -->
   - Build instructions
-- **Open issue:** [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1) — Missing GL-RM1 build configuration
+- **Open issue:** [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1) — Missing GL-RM1 build configuration <!-- cite: results/bsp_repos.toml#buildroot_issue_url -->
 
 ### Still Not Released
 - **U-Boot 2017.09** — No source repository published. GL.iNet has U-Boot repos for other platforms (IPQ, MTK, QCA) but not RV1126/RM1.

--- a/docs/GPL-COMPLIANCE-ANALYSIS.md
+++ b/docs/GPL-COMPLIANCE-ANALYSIS.md
@@ -4,14 +4,17 @@
 
 ---
 
-**GL.iNet has not released the GPL-required source code for the Comet (GL-RM1).**
+**GL.iNet has not released complete GPL-required source code for the Comet (GL-RM1).**
 
-The firmware contains Linux kernel 4.19.111, U-Boot 2017.09, BusyBox, and other GPL components. Users have requested source code on the GL.iNet forum. As of December 2025, only the application layer (KVMD) has been released. <!-- cite: results/rootfs.toml#kernel_version -->
+The firmware contains Linux kernel 4.19.111, U-Boot 2017.09, BusyBox, and other GPL components. In January 2026, GL.iNet published [kernel](https://github.com/gl-inet/kernel-4.19) and [Buildroot](https://github.com/gl-inet/buildroot-2018) repositories, but these contain only unmodified Rockchip BSP code without RM1-specific modifications or build configurations. See open issues: [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1), [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1). <!-- cite: results/rootfs.toml#kernel_version -->
 
 | Status | Components |
 |--------|------------|
-| **Not Released** | Linux kernel, U-Boot, BusyBox, bcmdhd WiFi driver |
+| **Not Released** | U-Boot, glibc (version mismatch with BSP) |
+| **Base BSP Only** | Linux kernel, BusyBox, Buildroot, bcmdhd, FFmpeg, BlueZ, Janus, Coreutils |
 | **Released** | KVMD application ([github.com/gl-inet/glkvm](https://github.com/gl-inet/glkvm)) |
+
+**Base BSP Only** means GL.iNet published the unmodified Rockchip SDK source but not the RM1-specific device trees, defconfigs, patches, or build instructions needed to reproduce the shipped firmware.
 
 **Firmware:** glkvm-RM1-1.7.2-1128-1764344791.img <!-- cite: results/binwalk.toml#firmware_file -->
 **SHA256:** `6044860b839b7ba74de2ec77b2a0764cd0c16ae27ad0f94deb715429c37e8f19`
@@ -75,7 +78,7 @@ When distributing a product containing copyleft software, the distributor must:
 | **Evidence** | Module vermagic: `4.19.111 SMP preempt mod_unload ARMv7 p2v8` | <!-- cite: results/rootfs.toml#kernel_version -->
 | **Platform** | Rockchip RV1126 (ARM Cortex-A7) |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE
+**Source Code Status:** BASE BSP PUBLISHED — [gl-inet/kernel-4.19](https://github.com/gl-inet/kernel-4.19) contains the Rockchip BSP kernel source (4.19.111), but RM1-specific device tree, kernel .config, and GL.iNet patches are missing.
 
 The Linux kernel is the core of the operating system. This specific version (4.19.111) with Rockchip RV1126 support contains: <!-- cite: results/rootfs.toml#kernel_version -->
 - Board-specific device tree modifications
@@ -98,7 +101,7 @@ The Linux kernel is the core of the operating system. This specific version (4.1
 | **Build Date** | Nov 27 2025 - 08:06:12 +0000 |
 | **Evidence** | String extracted from decompressed bootloader binary |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE
+**Source Code Status:** NOT PUBLICLY AVAILABLE — GL.iNet has not published any U-Boot source repository for the RV1126/RM1.
 
 The `-dirty` suffix indicates modifications were made beyond the tagged release. The bootloader includes:
 - RV1126 board support
@@ -120,7 +123,7 @@ The `-dirty` suffix indicates modifications were made beyond the tagged release.
 | **Build Date** | 2025-11-27 08:14:38 UTC |
 | **Evidence** | Version string in binary |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE (as configured/built)
+**Source Code Status:** BASE BSP PUBLISHED — BusyBox 1.27.2 source and Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but the RM1-specific BusyBox .config is missing.
 
 While upstream BusyBox source is available, the specific configuration used to build this binary determines which applets are included. The build configuration must be provided.
 
@@ -137,7 +140,7 @@ While upstream BusyBox source is available, the specific configuration used to b
 | **License** | GPL-3.0+ |
 | **Evidence** | Binary present at `/usr/bin/coreutils` |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE (as configured/built)
+**Source Code Status:** BASE BSP PUBLISHED — Coreutils package definition is in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1 Buildroot defconfig confirming package selection is missing.
 
 **Required Disclosure:**
 - Source code or reference to upstream version
@@ -152,7 +155,7 @@ While upstream BusyBox source is available, the specific configuration used to b
 | **Location** | `/system/lib/modules/bcmdhd.ko` |
 | **Evidence** | Kernel module in firmware |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE
+**Source Code Status:** BASE BSP PUBLISHED — bcmdhd driver source is in the [BSP kernel tree](https://github.com/gl-inet/kernel-4.19) under `drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/`, but the kernel .config confirming build options is missing.
 
 This is a Broadcom wireless driver that must be distributed with source code when included in a GPL kernel.
 
@@ -184,7 +187,7 @@ The following GPL-licensed utilities were identified in the firmware:
 | libavdevice | 58.5.100 | LGPL-2.1+ |
 | libavutil | 56.22.100 | LGPL-2.1+ |
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE
+**Source Code Status:** BASE BSP PUBLISHED — FFmpeg 4.1.3 source and 20 Rockchip patches are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but configure flags and any GL.iNet-specific patches are missing.
 
 FFmpeg's license depends on build configuration. If built with `--enable-gpl` or linked against GPL libraries (e.g., x264), the entire binary is GPL. Source must be provided either way.
 
@@ -217,7 +220,7 @@ The following libraries are under LGPL, requiring source code for the library (i
 
 **Note:** BlueZ, D-Bus, libmad, and Janus Gateway are GPL-licensed, requiring full source disclosure.
 
-**Source Code Status:** NOT PUBLICLY AVAILABLE (as configured/built)
+**Source Code Status:** BASE BSP PUBLISHED (except glibc) — BlueZ 5.50 (with 17 Rockchip patches), Janus v0.2.6, and other libraries are in [gl-inet/buildroot-2018](https://github.com/gl-inet/buildroot-2018), but RM1-specific build configurations are missing. glibc 2.28 is NOT in the BSP (which has 2.29); it likely comes from the external prebuilt toolchain.
 
 **Required Disclosure:**
 - Source code for all LGPL/GPL libraries
@@ -234,13 +237,14 @@ The following libraries are under LGPL, requiring source code for the library (i
 | **Buildroot Commit** | gd56bbacb |
 | **SDK Base** | Rockchip RV1126/RV1109 Linux SDK |
 
-The firmware is built using Buildroot, which is itself GPL-licensed. The complete Buildroot configuration, including:
-- Package selections
-- Kernel configuration
-- Toolchain configuration
+The firmware is built using Buildroot, which is itself GPL-licensed. GL.iNet has [published the Buildroot source](https://github.com/gl-inet/buildroot-2018), but it contains only the unmodified Rockchip BSP (commit `a439fb32`). The complete Buildroot configuration needed to reproduce the RM1 firmware, including:
+- RM1-specific defconfig (e.g., `configs/rockchip_rv1126_glrm1_defconfig`)
+- Package selections and overrides
+- Board overlay directory
 - Custom packages
+- Toolchain configuration
 
-...should be provided to enable recipients to reproduce the build.
+...has not been provided. See [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1).
 
 ---
 
@@ -253,12 +257,33 @@ GL.iNet has released the following on GitHub:
 - **Contents:** Application-layer daemon (Python, JavaScript, C)
 - **URL:** https://github.com/gl-inet/glkvm
 
-This repository contains only the userspace KVMD application, which is a derivative of the PiKVM project. It does **not** contain:
-- Linux kernel source
-- U-Boot source
-- Buildroot configuration
-- Device tree sources
-- Kernel module sources
+This repository contains only the userspace KVMD application, which is a derivative of the PiKVM project.
+
+### Kernel Source (gl-inet/kernel-4.19) — January 2026
+- **Contents:** Unmodified Rockchip RV1126 BSP kernel tree (4.19.111)
+- **URL:** https://github.com/gl-inet/kernel-4.19
+- **Verified as:** 1:1 match with Rockchip BSP commit `cc9228323509bf2bd59ed73ade9dd3276c97549c`
+- **Missing for RM1 compliance:**
+  - RM1 device tree (firmware ships `model = "rm1"`, no matching DTS in repo)
+  - Kernel .config used for RM1 build
+  - GL.iNet-specific patches or modifications
+  - Build instructions
+- **Open issue:** [kernel-4.19#1](https://github.com/gl-inet/kernel-4.19/issues/1) — Missing GL.inet changes
+
+### Buildroot (gl-inet/buildroot-2018) — January 2026
+- **Contents:** Unmodified Rockchip BSP Buildroot (2018.02-rc3)
+- **URL:** https://github.com/gl-inet/buildroot-2018
+- **Verified as:** 1:1 match with Rockchip BSP commit `a439fb32a06a78a2283aa03e32cabb6e531e73bd`
+- **Missing for RM1 compliance:**
+  - RM1 Buildroot defconfig (none of the 30 existing defconfigs target the RM1)
+  - Board overlay directory (`board/rockchip/` referenced by defconfigs is absent)
+  - Any GL.iNet/RM1-specific packages or patches
+  - Build instructions
+- **Open issue:** [buildroot-2018#1](https://github.com/gl-inet/buildroot-2018/issues/1) — Missing GL-RM1 build configuration
+
+### Still Not Released
+- **U-Boot 2017.09** — No source repository published. GL.iNet has U-Boot repos for other platforms (IPQ, MTK, QCA) but not RV1126/RM1.
+- **glibc 2.28** — The BSP Buildroot contains glibc 2.29, but the firmware uses 2.28 (likely from the external prebuilt ARM toolchain). Neither the toolchain nor its glibc source is published.
 
 ---
 
@@ -447,6 +472,8 @@ Supporting evidence files:
 - [GL.iNet GLKVM GitHub Repository](https://github.com/gl-inet/glkvm)
 - [Rockchip Open Source Documentation](https://opensource.rock-chips.com/)
 - [Rockchip U-Boot Repository](https://github.com/rockchip-linux/u-boot)
+- [GL.iNet Kernel 4.19 Repository](https://github.com/gl-inet/kernel-4.19)
+- [GL.iNet Buildroot 2018 Repository](https://github.com/gl-inet/buildroot-2018)
 
 ---
 
@@ -455,3 +482,4 @@ Supporting evidence files:
 | Version | Date | Changes |
 |---------|------|---------|
 | 0.3 | December 2025 | Initial analysis; added LGPL components, FFmpeg, clarified responsible parties |
+| 0.4 | March 2026 | Updated for GL.iNet's January 2026 BSP repo publications; documented remaining compliance gaps |

--- a/results/bsp_repos.toml
+++ b/results/bsp_repos.toml
@@ -43,6 +43,10 @@ kernel_glinet_files_files = []
 # Method: list existing RV1126 defconfigs
 kernel_rv1126_defconfigs = ["arch/arm/configs/rv1126_defconfig", "arch/arm/configs/rv1126_robot_defconfig"]
 
+# Source: compare tree SHA against known value
+# Method: True if tree SHA matches 1dc3d7b37ac2410a89b20d376c3c43012f7baa24
+kernel_tree_sha_unchanged = true
+
 # Source: external verification
 # Method: diff between GL.iNet commit and BSP reference (by samueldr)
 kernel_diff_gist_url = "https://gist.github.com/samueldr/b68142df0b7843263294e913fee4f037"
@@ -87,6 +91,10 @@ buildroot_board_overlay_present = false
 
 # Source: git ls-tree -r HEAD
 # Method: list existing RV1126 defconfigs (none target RM1)
+# Source: compare tree SHA against known value
+# Method: True if tree SHA matches 7c66b4fcb991a19aed0d51bdfa7ab77c27b08bc8
+buildroot_tree_sha_unchanged = true
+
 buildroot_rv1126_defconfigs = ["configs/rockchip_rv1126_battery_evb_defconfig", "configs/rockchip_rv1126_battery_evb_v10_defconfig", "configs/rockchip_rv1126_battery_ipc_defconfig", "configs/rockchip_rv1126_evb_dualcam_tb_defconfig", "configs/rockchip_rv1126_evb_spi_nor_tb_defconfig", "configs/rockchip_rv1126_evb_tb_defconfig", "configs/rockchip_rv1126_robot_defconfig", "configs/rockchip_rv1126_robot_recovery_defconfig", "configs/rockchip_rv1126_rv1109_ab_defconfig", "configs/rockchip_rv1126_rv1109_cvr_defconfig", "configs/rockchip_rv1126_rv1109_defconfig", "configs/rockchip_rv1126_rv1109_facial_gate_defconfig", "configs/rockchip_rv1126_rv1109_libs_defconfig", "configs/rockchip_rv1126_rv1109_pcba_defconfig", "configs/rockchip_rv1126_rv1109_ramboot_uvcc_defconfig", "configs/rockchip_rv1126_rv1109_recovery_defconfig", "configs/rockchip_rv1126_rv1109_sl_defconfig", "configs/rockchip_rv1126_rv1109_spi_nand_defconfig", "configs/rockchip_rv1126_rv1109_spi_nand_recovery_defconfig", "configs/rockchip_rv1126_rv1109_systemd_defconfig", "configs/rockchip_rv1126_rv1109_tiny_defconfig", "configs/rockchip_rv1126_rv1109_toolchain_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_mult_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_spi_nand_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_spi_nor_defconfig", "configs/rockchip_rv1126_rv1109_weston_qt_defconfig", "configs/rockchip_rv1126_sllock_defconfig", "configs/rockchip_rv1126_snapshot_defconfig", "configs/rockchip_rv1126_tb_recovery_defconfig"]
 
 buildroot_total_files = 15835

--- a/results/bsp_repos.toml
+++ b/results/bsp_repos.toml
@@ -1,0 +1,92 @@
+# BSP repository verification results
+# Generated: 2026-03-03T04:31:49.201900+00:00
+# Method: git clone --depth=1 --no-checkout --filter=blob:none, git ls-tree -r HEAD
+
+# --- Kernel Repository (gl-inet/kernel-4.19) ---
+
+# Source: GitHub repository
+# Method: constant
+kernel_repo_url = "https://github.com/gl-inet/kernel-4.19"
+kernel_issue_url = "https://github.com/gl-inet/kernel-4.19/issues/1"
+
+# Source: git log -1
+# Method: shallow clone, read commit metadata
+kernel_head_commit = "fc316e95ef5836b141bfbebd39ab3e62287a512a"
+kernel_tree_sha = "1dc3d7b37ac2410a89b20d376c3c43012f7baa24"
+kernel_commit_author = "xiaojiang2017 <luoyejiang@gl-inet.com>"
+kernel_commit_date = "2026-01-23T15:04:30+08:00"
+kernel_commit_subject = "first commit"
+kernel_commit_count = 1
+
+# Source: compare HEAD with known Rockchip BSP commit
+# Method: GL.iNet squashed BSP into single commit; content equivalence
+# verified externally via diff (see issue_url)
+kernel_bsp_reference_commit = "cc9228323509bf2bd59ed73ade9dd3276c97549c"
+kernel_is_squashed_import = true
+
+# Source: git ls-tree -r HEAD | fnmatch
+# Method: search for RM1 device tree sources
+kernel_rm1_dts_found = false
+kernel_rm1_dts_files = []
+
+# Source: git ls-tree -r HEAD | fnmatch
+# Method: search for RM1 kernel defconfig
+kernel_rm1_defconfig_found = false
+kernel_rm1_defconfig_files = []
+
+# Source: git ls-tree -r HEAD | fnmatch
+# Method: search for GL.iNet-specific files
+kernel_glinet_files_found = false
+kernel_glinet_files_files = []
+
+# Source: git ls-tree -r HEAD
+# Method: list existing RV1126 defconfigs
+kernel_rv1126_defconfigs = ["arch/arm/configs/rv1126_defconfig", "arch/arm/configs/rv1126_robot_defconfig"]
+
+# Source: external verification
+# Method: diff between GL.iNet commit and BSP reference (by samueldr)
+kernel_diff_gist_url = "https://gist.github.com/samueldr/b68142df0b7843263294e913fee4f037"
+
+kernel_total_files = 72710
+
+# --- Buildroot Repository (gl-inet/buildroot-2018) ---
+
+# Source: GitHub repository
+# Method: constant
+buildroot_repo_url = "https://github.com/gl-inet/buildroot-2018"
+buildroot_issue_url = "https://github.com/gl-inet/buildroot-2018/issues/1"
+
+# Source: git log -1
+# Method: shallow clone, read commit metadata
+buildroot_head_commit = "4a4f065abadf26c419c7c4333965b7c136f05c6a"
+buildroot_tree_sha = "7c66b4fcb991a19aed0d51bdfa7ab77c27b08bc8"
+buildroot_commit_author = "xiaojiang2017 <luoyejiang@gl-inet.com>"
+buildroot_commit_date = "2026-01-23T15:18:31+08:00"
+buildroot_commit_subject = "first commit"
+buildroot_commit_count = 1
+
+# Source: compare HEAD with known Rockchip BSP commit
+# Method: GL.iNet squashed BSP into single commit; content equivalence
+# verified externally via diff (see issue_url)
+buildroot_bsp_reference_commit = "a439fb32a06a78a2283aa03e32cabb6e531e73bd"
+buildroot_is_squashed_import = true
+
+# Source: git ls-tree -r HEAD | fnmatch
+# Method: search for RM1 Buildroot defconfig
+buildroot_rm1_defconfig_found = false
+buildroot_rm1_defconfig_files = []
+
+# Source: git ls-tree -r HEAD | fnmatch
+# Method: search for GL.iNet-specific files
+buildroot_glinet_files_found = false
+buildroot_glinet_files_files = []
+
+# Source: git ls-tree -r HEAD
+# Method: check for board/rockchip/ overlay directory
+buildroot_board_overlay_present = false
+
+# Source: git ls-tree -r HEAD
+# Method: list existing RV1126 defconfigs (none target RM1)
+buildroot_rv1126_defconfigs = ["configs/rockchip_rv1126_battery_evb_defconfig", "configs/rockchip_rv1126_battery_evb_v10_defconfig", "configs/rockchip_rv1126_battery_ipc_defconfig", "configs/rockchip_rv1126_evb_dualcam_tb_defconfig", "configs/rockchip_rv1126_evb_spi_nor_tb_defconfig", "configs/rockchip_rv1126_evb_tb_defconfig", "configs/rockchip_rv1126_robot_defconfig", "configs/rockchip_rv1126_robot_recovery_defconfig", "configs/rockchip_rv1126_rv1109_ab_defconfig", "configs/rockchip_rv1126_rv1109_cvr_defconfig", "configs/rockchip_rv1126_rv1109_defconfig", "configs/rockchip_rv1126_rv1109_facial_gate_defconfig", "configs/rockchip_rv1126_rv1109_libs_defconfig", "configs/rockchip_rv1126_rv1109_pcba_defconfig", "configs/rockchip_rv1126_rv1109_ramboot_uvcc_defconfig", "configs/rockchip_rv1126_rv1109_recovery_defconfig", "configs/rockchip_rv1126_rv1109_sl_defconfig", "configs/rockchip_rv1126_rv1109_spi_nand_defconfig", "configs/rockchip_rv1126_rv1109_spi_nand_recovery_defconfig", "configs/rockchip_rv1126_rv1109_systemd_defconfig", "configs/rockchip_rv1126_rv1109_tiny_defconfig", "configs/rockchip_rv1126_rv1109_toolchain_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_mult_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_spi_nand_defconfig", "configs/rockchip_rv1126_rv1109_uvcc_spi_nor_defconfig", "configs/rockchip_rv1126_rv1109_weston_qt_defconfig", "configs/rockchip_rv1126_sllock_defconfig", "configs/rockchip_rv1126_snapshot_defconfig", "configs/rockchip_rv1126_tb_recovery_defconfig"]
+
+buildroot_total_files = 15835

--- a/scripts/verify_bsp_repos.py
+++ b/scripts/verify_bsp_repos.py
@@ -16,7 +16,7 @@ import fnmatch
 import subprocess
 import sys
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import tomlkit
@@ -195,7 +195,7 @@ def build_toml() -> str:
     """Run verification and return TOML string."""
     doc = tomlkit.document()
     doc.add(tomlkit.comment("BSP repository verification results"))
-    doc.add(tomlkit.comment(f"Generated: {datetime.now(datetime.UTC).isoformat()}"))
+    doc.add(tomlkit.comment(f"Generated: {datetime.now(UTC).isoformat()}"))
     doc.add(
         tomlkit.comment(
             "Method: git clone --depth=1 --no-checkout --filter=blob:none, git ls-tree -r HEAD"

--- a/scripts/verify_bsp_repos.py
+++ b/scripts/verify_bsp_repos.py
@@ -17,7 +17,8 @@ import subprocess
 import sys
 import tempfile
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
 
 import tomlkit
 
@@ -125,9 +126,15 @@ def list_defconfigs(files: list[str], prefix: str) -> list[str]:
     return sorted(f for f in files if f.startswith(prefix) and "defconfig" in f)
 
 
+def repo_name_from_url(url: str) -> str:
+    """Extract repository name from a git URL."""
+    path = PurePosixPath(urlparse(url).path)
+    return path.stem  # strips .git suffix and returns last component
+
+
 def verify_repo(url: str, tmpdir: str) -> tuple[dict[str, str], list[str], int]:
     """Clone and return (commit_info, file_list, commit_count)."""
-    name = url.rstrip("/").split("/")[-1].replace(".git", "")
+    name = repo_name_from_url(url)
     repo = Path(tmpdir) / name
     print(f"Cloning {url} ...", file=sys.stderr)
     clone_shallow(url, repo)

--- a/scripts/verify_bsp_repos.py
+++ b/scripts/verify_bsp_repos.py
@@ -21,9 +21,19 @@ from pathlib import Path
 
 import tomlkit
 
-# Known Rockchip BSP commit hashes (referenced in GL.iNet repo issues)
+# Known Rockchip BSP commit hashes.
+# Source: samueldr's diff analysis (KERNEL_DIFF_GIST below) compared GL.iNet's
+# squashed commit against the Rockchip SDK release and found near-identical content.
+# The Rockchip BSP SDK is distributed privately to partners; these commits are NOT
+# reachable from the public rockchip-linux/kernel GitHub repo, so automated
+# verification against upstream is not feasible.
 KERNEL_BSP_COMMIT = "cc9228323509bf2bd59ed73ade9dd3276c97549c"
 BUILDROOT_BSP_COMMIT = "a439fb32a06a78a2283aa03e32cabb6e531e73bd"
+
+# Known tree SHAs from GL.iNet repos (content-addressable).
+# If these change on a future run, GL.iNet has modified their repos.
+KERNEL_KNOWN_TREE_SHA = "1dc3d7b37ac2410a89b20d376c3c43012f7baa24"
+BUILDROOT_KNOWN_TREE_SHA = "7c66b4fcb991a19aed0d51bdfa7ab77c27b08bc8"
 
 # Repository URLs
 KERNEL_REPO_URL = "https://github.com/gl-inet/kernel-4.19.git"
@@ -206,6 +216,13 @@ def build_toml() -> str:
     with tempfile.TemporaryDirectory(prefix="bsp_verify_") as tmpdir:
         # --- Kernel ---
         k_info, k_files, k_count = verify_repo(KERNEL_REPO_URL, tmpdir)
+        k_tree_unchanged = k_info["tree_sha"] == KERNEL_KNOWN_TREE_SHA
+        if not k_tree_unchanged:
+            print(
+                f"  WARNING: tree SHA changed! expected {KERNEL_KNOWN_TREE_SHA}, "
+                f"got {k_info['tree_sha']}",
+                file=sys.stderr,
+            )
         k_rm1_dts = find_matching(k_files, KERNEL_RM1_DTS_PATTERNS)
         k_rm1_defconfig = find_matching(k_files, KERNEL_RM1_DEFCONFIG_PATTERNS)
         k_glinet_files = find_matching(k_files, GLINET_PATTERNS)
@@ -249,6 +266,12 @@ def build_toml() -> str:
                     k_rv1126_defconfigs,
                 ),
                 (
+                    "tree_sha_unchanged",
+                    "compare tree SHA against known value",
+                    f"True if tree SHA matches {KERNEL_KNOWN_TREE_SHA}",
+                    k_tree_unchanged,
+                ),
+                (
                     "diff_gist_url",
                     "external verification",
                     "diff between GL.iNet commit and BSP reference (by samueldr)",
@@ -261,6 +284,13 @@ def build_toml() -> str:
 
         # --- Buildroot ---
         b_info, b_files, b_count = verify_repo(BUILDROOT_REPO_URL, tmpdir)
+        b_tree_unchanged = b_info["tree_sha"] == BUILDROOT_KNOWN_TREE_SHA
+        if not b_tree_unchanged:
+            print(
+                f"  WARNING: tree SHA changed! expected {BUILDROOT_KNOWN_TREE_SHA}, "
+                f"got {b_info['tree_sha']}",
+                file=sys.stderr,
+            )
         b_rm1_defconfig = find_matching(b_files, BUILDROOT_RM1_DEFCONFIG_PATTERNS)
         b_glinet_files = find_matching(b_files, GLINET_PATTERNS)
         b_rv1126_defconfigs = list_defconfigs(b_files, "configs/rockchip_rv1126")
@@ -302,6 +332,12 @@ def build_toml() -> str:
                     "git ls-tree -r HEAD",
                     "list existing RV1126 defconfigs (none target RM1)",
                     b_rv1126_defconfigs,
+                ),
+                (
+                    "tree_sha_unchanged",
+                    "compare tree SHA against known value",
+                    f"True if tree SHA matches {BUILDROOT_KNOWN_TREE_SHA}",
+                    b_tree_unchanged,
                 ),
             ],
         )

--- a/scripts/verify_bsp_repos.py
+++ b/scripts/verify_bsp_repos.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Verify GL.iNet BSP repository contents against known Rockchip BSP commits.
+
+Usage: uv run python3 scripts/verify_bsp_repos.py [--write]
+
+Clones gl-inet/kernel-4.19 and gl-inet/buildroot-2018 (shallow, no checkout),
+records commit metadata, and checks for absence of RM1-specific artifacts
+(device trees, defconfigs, board overlays).
+
+With --write, saves results to results/bsp_repos.toml.
+Otherwise prints TOML to stdout.
+"""
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import tomlkit
+
+# Known Rockchip BSP commit hashes (referenced in GL.iNet repo issues)
+KERNEL_BSP_COMMIT = "cc9228323509bf2bd59ed73ade9dd3276c97549c"
+BUILDROOT_BSP_COMMIT = "a439fb32a06a78a2283aa03e32cabb6e531e73bd"
+
+# Repository URLs
+KERNEL_REPO_URL = "https://github.com/gl-inet/kernel-4.19.git"
+BUILDROOT_REPO_URL = "https://github.com/gl-inet/buildroot-2018.git"
+
+# External verification references
+KERNEL_ISSUE_URL = "https://github.com/gl-inet/kernel-4.19/issues/1"
+BUILDROOT_ISSUE_URL = "https://github.com/gl-inet/buildroot-2018/issues/1"
+KERNEL_DIFF_GIST = "https://gist.github.com/samueldr/b68142df0b7843263294e913fee4f037"
+
+# Patterns for RM1-specific files
+KERNEL_RM1_DTS_PATTERNS = [
+    "arch/arm/boot/dts/*rm1*",
+    "arch/arm/boot/dts/*glrm1*",
+    "arch/arm/boot/dts/*gl-rm1*",
+]
+KERNEL_RM1_DEFCONFIG_PATTERNS = [
+    "arch/arm/configs/*rm1*",
+    "arch/arm/configs/*glrm1*",
+    "arch/arm/configs/*gl_rm1*",
+]
+BUILDROOT_RM1_DEFCONFIG_PATTERNS = [
+    "configs/*rm1*",
+    "configs/*glrm1*",
+    "configs/*gl_rm1*",
+]
+# Broad GL.iNet search patterns (case-insensitive via fnmatch)
+GLINET_PATTERNS = [
+    "*gl-inet*",
+    "*glinet*",
+    "*gl_inet*",
+]
+
+
+def git(*args: str, cwd: Path | None = None) -> str:
+    """Run a git command and return stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def clone_shallow(url: str, dest: Path) -> None:
+    """Shallow clone without checkout (downloads tree objects only)."""
+    git("clone", "--depth=1", "--no-checkout", "--filter=blob:none", url, str(dest))
+
+
+def get_commit_info(repo: Path) -> dict[str, str]:
+    """Get HEAD commit metadata."""
+    fmt = "%H%n%an%n%ae%n%aI%n%s%n%T"
+    output = git("log", "-1", f"--format={fmt}", cwd=repo)
+    lines = output.split("\n")
+    return {
+        "commit": lines[0],
+        "author_name": lines[1],
+        "author_email": lines[2],
+        "author_date": lines[3],
+        "subject": lines[4],
+        "tree_sha": lines[5],
+    }
+
+
+def list_files(repo: Path) -> list[str]:
+    """List all files in HEAD tree without checking out."""
+    output = git("ls-tree", "-r", "--name-only", "HEAD", cwd=repo)
+    return output.split("\n") if output else []
+
+
+def count_commits(repo: Path) -> int:
+    """Count commits reachable from HEAD (may be limited by clone depth)."""
+    return int(git("rev-list", "--count", "HEAD", cwd=repo))
+
+
+def find_matching(files: list[str], patterns: list[str]) -> list[str]:
+    """Find files matching any of the given glob patterns."""
+    matches = []
+    for f in files:
+        if any(fnmatch.fnmatch(f.lower(), p) for p in patterns):
+            matches.append(f)
+    return sorted(matches)
+
+
+def list_defconfigs(files: list[str], prefix: str) -> list[str]:
+    """List existing defconfig files under a prefix."""
+    return sorted(f for f in files if f.startswith(prefix) and "defconfig" in f)
+
+
+def verify_repo(url: str, tmpdir: str) -> tuple[dict[str, str], list[str], int]:
+    """Clone and return (commit_info, file_list, commit_count)."""
+    name = url.rstrip("/").split("/")[-1].replace(".git", "")
+    repo = Path(tmpdir) / name
+    print(f"Cloning {url} ...", file=sys.stderr)
+    clone_shallow(url, repo)
+    info = get_commit_info(repo)
+    files = list_files(repo)
+    count = count_commits(repo)
+    print(f"  HEAD: {info['commit']}", file=sys.stderr)
+    print(f"  Tree: {info['tree_sha']}", file=sys.stderr)
+    print(f"  Author: {info['author_name']} <{info['author_email']}>", file=sys.stderr)
+    print(f"  Date: {info['author_date']}", file=sys.stderr)
+    print(f"  Subject: {info['subject']}", file=sys.stderr)
+    print(f"  Commits: {count}", file=sys.stderr)
+    print(f"  Files: {len(files)}", file=sys.stderr)
+    return info, files, count
+
+
+def add_repo_section(
+    doc: tomlkit.TOMLDocument,
+    prefix: str,
+    label: str,
+    url: str,
+    bsp_commit: str,
+    issue_url: str,
+    info: dict[str, str],
+    files: list[str],
+    commit_count: int,
+    rm1_checks: list[tuple[str, str, list[str], list[str]]],
+    extra_checks: list[tuple[str, str, str, object]] | None = None,
+) -> None:
+    """Add a repository verification section to the TOML document."""
+    doc.add(tomlkit.comment(f"--- {label} ---"))
+    doc.add(tomlkit.nl())
+
+    doc.add(tomlkit.comment("Source: GitHub repository"))
+    doc.add(tomlkit.comment("Method: constant"))
+    doc[f"{prefix}_repo_url"] = url.replace(".git", "")
+    doc[f"{prefix}_issue_url"] = issue_url
+
+    doc.add(tomlkit.nl())
+    doc.add(tomlkit.comment("Source: git log -1"))
+    doc.add(tomlkit.comment("Method: shallow clone, read commit metadata"))
+    doc[f"{prefix}_head_commit"] = info["commit"]
+    doc[f"{prefix}_tree_sha"] = info["tree_sha"]
+    doc[f"{prefix}_commit_author"] = f"{info['author_name']} <{info['author_email']}>"
+    doc[f"{prefix}_commit_date"] = info["author_date"]
+    doc[f"{prefix}_commit_subject"] = info["subject"]
+    doc[f"{prefix}_commit_count"] = commit_count
+
+    doc.add(tomlkit.nl())
+    doc.add(tomlkit.comment("Source: compare HEAD with known Rockchip BSP commit"))
+    doc.add(tomlkit.comment("Method: GL.iNet squashed BSP into single commit; content equivalence"))
+    doc.add(tomlkit.comment("verified externally via diff (see issue_url)"))
+    doc[f"{prefix}_bsp_reference_commit"] = bsp_commit
+    doc[f"{prefix}_is_squashed_import"] = commit_count == 1
+
+    for field_suffix, method_comment, _patterns, found_files in rm1_checks:
+        doc.add(tomlkit.nl())
+        doc.add(tomlkit.comment("Source: git ls-tree -r HEAD | fnmatch"))
+        doc.add(tomlkit.comment(f"Method: {method_comment}"))
+        doc[f"{prefix}_{field_suffix}_found"] = len(found_files) > 0
+        doc[f"{prefix}_{field_suffix}_files"] = found_files
+
+    if extra_checks:
+        for field_suffix, source_comment, method_comment, value in extra_checks:
+            doc.add(tomlkit.nl())
+            doc.add(tomlkit.comment(f"Source: {source_comment}"))
+            doc.add(tomlkit.comment(f"Method: {method_comment}"))
+            doc[f"{prefix}_{field_suffix}"] = value
+
+    doc.add(tomlkit.nl())
+    doc[f"{prefix}_total_files"] = len(files)
+
+
+def build_toml() -> str:
+    """Run verification and return TOML string."""
+    doc = tomlkit.document()
+    doc.add(tomlkit.comment("BSP repository verification results"))
+    doc.add(tomlkit.comment(f"Generated: {datetime.now(datetime.UTC).isoformat()}"))
+    doc.add(
+        tomlkit.comment(
+            "Method: git clone --depth=1 --no-checkout --filter=blob:none, git ls-tree -r HEAD"
+        )
+    )
+    doc.add(tomlkit.nl())
+
+    with tempfile.TemporaryDirectory(prefix="bsp_verify_") as tmpdir:
+        # --- Kernel ---
+        k_info, k_files, k_count = verify_repo(KERNEL_REPO_URL, tmpdir)
+        k_rm1_dts = find_matching(k_files, KERNEL_RM1_DTS_PATTERNS)
+        k_rm1_defconfig = find_matching(k_files, KERNEL_RM1_DEFCONFIG_PATTERNS)
+        k_glinet_files = find_matching(k_files, GLINET_PATTERNS)
+        k_rv1126_defconfigs = list_defconfigs(k_files, "arch/arm/configs/rv1126")
+
+        add_repo_section(
+            doc,
+            prefix="kernel",
+            label="Kernel Repository (gl-inet/kernel-4.19)",
+            url=KERNEL_REPO_URL,
+            bsp_commit=KERNEL_BSP_COMMIT,
+            issue_url=KERNEL_ISSUE_URL,
+            info=k_info,
+            files=k_files,
+            commit_count=k_count,
+            rm1_checks=[
+                (
+                    "rm1_dts",
+                    "search for RM1 device tree sources",
+                    KERNEL_RM1_DTS_PATTERNS,
+                    k_rm1_dts,
+                ),
+                (
+                    "rm1_defconfig",
+                    "search for RM1 kernel defconfig",
+                    KERNEL_RM1_DEFCONFIG_PATTERNS,
+                    k_rm1_defconfig,
+                ),
+                (
+                    "glinet_files",
+                    "search for GL.iNet-specific files",
+                    GLINET_PATTERNS,
+                    k_glinet_files,
+                ),
+            ],
+            extra_checks=[
+                (
+                    "rv1126_defconfigs",
+                    "git ls-tree -r HEAD",
+                    "list existing RV1126 defconfigs",
+                    k_rv1126_defconfigs,
+                ),
+                (
+                    "diff_gist_url",
+                    "external verification",
+                    "diff between GL.iNet commit and BSP reference (by samueldr)",
+                    KERNEL_DIFF_GIST,
+                ),
+            ],
+        )
+
+        doc.add(tomlkit.nl())
+
+        # --- Buildroot ---
+        b_info, b_files, b_count = verify_repo(BUILDROOT_REPO_URL, tmpdir)
+        b_rm1_defconfig = find_matching(b_files, BUILDROOT_RM1_DEFCONFIG_PATTERNS)
+        b_glinet_files = find_matching(b_files, GLINET_PATTERNS)
+        b_rv1126_defconfigs = list_defconfigs(b_files, "configs/rockchip_rv1126")
+        b_has_board_overlay = any(f.startswith("board/rockchip/") for f in b_files)
+
+        add_repo_section(
+            doc,
+            prefix="buildroot",
+            label="Buildroot Repository (gl-inet/buildroot-2018)",
+            url=BUILDROOT_REPO_URL,
+            bsp_commit=BUILDROOT_BSP_COMMIT,
+            issue_url=BUILDROOT_ISSUE_URL,
+            info=b_info,
+            files=b_files,
+            commit_count=b_count,
+            rm1_checks=[
+                (
+                    "rm1_defconfig",
+                    "search for RM1 Buildroot defconfig",
+                    BUILDROOT_RM1_DEFCONFIG_PATTERNS,
+                    b_rm1_defconfig,
+                ),
+                (
+                    "glinet_files",
+                    "search for GL.iNet-specific files",
+                    GLINET_PATTERNS,
+                    b_glinet_files,
+                ),
+            ],
+            extra_checks=[
+                (
+                    "board_overlay_present",
+                    "git ls-tree -r HEAD",
+                    "check for board/rockchip/ overlay directory",
+                    b_has_board_overlay,
+                ),
+                (
+                    "rv1126_defconfigs",
+                    "git ls-tree -r HEAD",
+                    "list existing RV1126 defconfigs (none target RM1)",
+                    b_rv1126_defconfigs,
+                ),
+            ],
+        )
+
+    return tomlkit.dumps(doc)
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Verify GL.iNet BSP repositories against known Rockchip BSP commits"
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write results to results/bsp_repos.toml",
+    )
+    args = parser.parse_args()
+
+    toml_output = build_toml()
+
+    if args.write:
+        out_path = Path("results/bsp_repos.toml")
+        out_path.parent.mkdir(exist_ok=True)
+        out_path.write_text(toml_output)
+        print(f"Wrote {out_path}", file=sys.stderr)
+    else:
+        print(toml_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_verify_bsp_repos.py
+++ b/tests/test_verify_bsp_repos.py
@@ -26,6 +26,7 @@ from verify_bsp_repos import (
     list_defconfigs,
     list_files,
     main,
+    repo_name_from_url,
     verify_repo,
 )
 
@@ -362,6 +363,26 @@ class TestVerifyRepo:
         # clone_shallow should be called with dest = tmpdir / "kernel-4.19"
         clone_dest = mock_clone.call_args[0][1]
         assert clone_dest == tmp_path / "kernel-4.19"
+
+
+class TestRepoNameFromUrl:
+    """Test repo_name_from_url() function."""
+
+    def test_strips_git_suffix(self) -> None:
+        """Test that .git suffix is stripped."""
+        assert repo_name_from_url("https://github.com/gl-inet/kernel-4.19.git") == "kernel-4.19"
+
+    def test_no_git_suffix(self) -> None:
+        """Test URL without .git suffix."""
+        assert repo_name_from_url("https://github.com/gl-inet/buildroot-2018") == "buildroot-2018"
+
+    def test_trailing_slash(self) -> None:
+        """Test URL with trailing slash."""
+        assert repo_name_from_url("https://github.com/gl-inet/kernel-4.19.git/") == "kernel-4.19"
+
+    def test_url_with_query_params(self) -> None:
+        """Test URL with query parameters."""
+        assert repo_name_from_url("https://github.com/gl-inet/repo.git?ref=main") == "repo"
 
 
 class TestBuildToml:

--- a/tests/test_verify_bsp_repos.py
+++ b/tests/test_verify_bsp_repos.py
@@ -1,0 +1,511 @@
+"""Tests for scripts/verify_bsp_repos.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import tomlkit
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from verify_bsp_repos import (
+    build_toml,
+    clone_shallow,
+    count_commits,
+    find_matching,
+    get_commit_info,
+    git,
+    list_defconfigs,
+    list_files,
+    main,
+    verify_repo,
+)
+
+
+class TestGit:
+    """Test git() helper function."""
+
+    @patch("subprocess.run")
+    def test_git_returns_stripped_stdout(self, mock_run: Any) -> None:
+        """Test that git() returns stripped stdout."""
+        mock_run.return_value = MagicMock(stdout="  hello world  \n")
+
+        result = git("status")
+
+        assert result == "hello world"
+        mock_run.assert_called_once_with(
+            ["git", "status"],
+            cwd=None,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("subprocess.run")
+    def test_git_passes_multiple_args(self, mock_run: Any) -> None:
+        """Test that git() passes all arguments to subprocess."""
+        mock_run.return_value = MagicMock(stdout="output\n")
+
+        git("log", "-1", "--format=%H")
+
+        mock_run.assert_called_once_with(
+            ["git", "log", "-1", "--format=%H"],
+            cwd=None,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("subprocess.run")
+    def test_git_passes_cwd(self, mock_run: Any) -> None:
+        """Test that git() passes cwd to subprocess."""
+        mock_run.return_value = MagicMock(stdout="output\n")
+        repo = Path("/tmp/repo")
+
+        git("status", cwd=repo)
+
+        mock_run.assert_called_once_with(
+            ["git", "status"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("subprocess.run")
+    def test_git_raises_on_failure(self, mock_run: Any) -> None:
+        """Test that git() propagates subprocess errors."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git("status")
+
+
+class TestFindMatching:
+    """Test find_matching() pure function."""
+
+    def test_finds_matching_files(self) -> None:
+        """Test finding files that match glob patterns."""
+        files = [
+            "arch/arm/boot/dts/rv1126-rm1.dts",
+            "arch/arm/boot/dts/rv1126-evb.dts",
+            "arch/arm/boot/dts/rv1126-glrm1.dts",
+        ]
+        patterns = ["arch/arm/boot/dts/*rm1*", "arch/arm/boot/dts/*glrm1*"]
+
+        result = find_matching(files, patterns)
+
+        assert result == [
+            "arch/arm/boot/dts/rv1126-glrm1.dts",
+            "arch/arm/boot/dts/rv1126-rm1.dts",
+        ]
+
+    def test_returns_empty_on_no_match(self) -> None:
+        """Test that no matches returns empty list."""
+        files = ["arch/arm/boot/dts/rv1126-evb.dts"]
+        patterns = ["arch/arm/boot/dts/*rm1*"]
+
+        result = find_matching(files, patterns)
+
+        assert result == []
+
+    def test_case_insensitive_matching(self) -> None:
+        """Test that matching is case-insensitive (lowercases filename)."""
+        files = ["configs/GL-INET-defconfig"]
+        patterns = ["*gl-inet*"]
+
+        result = find_matching(files, patterns)
+
+        assert result == ["configs/GL-INET-defconfig"]
+
+    def test_returns_sorted_results(self) -> None:
+        """Test that results are sorted."""
+        files = ["c.txt", "a.txt", "b.txt"]
+        patterns = ["*.txt"]
+
+        result = find_matching(files, patterns)
+
+        assert result == ["a.txt", "b.txt", "c.txt"]
+
+    def test_empty_files_list(self) -> None:
+        """Test with empty files list."""
+        result = find_matching([], ["*.txt"])
+
+        assert result == []
+
+    def test_empty_patterns_list(self) -> None:
+        """Test with empty patterns list."""
+        result = find_matching(["a.txt"], [])
+
+        assert result == []
+
+
+class TestListDefconfigs:
+    """Test list_defconfigs() pure function."""
+
+    def test_finds_defconfigs_with_prefix(self) -> None:
+        """Test finding defconfig files under a prefix."""
+        files = [
+            "arch/arm/configs/rv1126_defconfig",
+            "arch/arm/configs/rv1126_robot_defconfig",
+            "arch/arm/configs/rv1109_defconfig",
+            "arch/arm/configs/other_config",
+        ]
+
+        result = list_defconfigs(files, "arch/arm/configs/rv1126")
+
+        assert result == [
+            "arch/arm/configs/rv1126_defconfig",
+            "arch/arm/configs/rv1126_robot_defconfig",
+        ]
+
+    def test_returns_empty_on_no_match(self) -> None:
+        """Test that no matches returns empty list."""
+        files = ["arch/arm/configs/other_defconfig"]
+
+        result = list_defconfigs(files, "arch/arm/configs/rv1126")
+
+        assert result == []
+
+    def test_requires_defconfig_in_name(self) -> None:
+        """Test that files must contain 'defconfig' in name."""
+        files = [
+            "arch/arm/configs/rv1126_defconfig",
+            "arch/arm/configs/rv1126_config",
+        ]
+
+        result = list_defconfigs(files, "arch/arm/configs/rv1126")
+
+        assert result == ["arch/arm/configs/rv1126_defconfig"]
+
+    def test_returns_sorted_results(self) -> None:
+        """Test that results are sorted."""
+        files = [
+            "configs/rockchip_rv1126_b_defconfig",
+            "configs/rockchip_rv1126_a_defconfig",
+        ]
+
+        result = list_defconfigs(files, "configs/rockchip_rv1126")
+
+        assert result == [
+            "configs/rockchip_rv1126_a_defconfig",
+            "configs/rockchip_rv1126_b_defconfig",
+        ]
+
+
+class TestGetCommitInfo:
+    """Test get_commit_info() function."""
+
+    @patch("verify_bsp_repos.git")
+    def test_parses_commit_info(self, mock_git: Any) -> None:
+        """Test parsing git log output into commit info dict."""
+        mock_git.return_value = (
+            "abc123def456\n"
+            "John Doe\n"
+            "john@example.com\n"
+            "2026-01-15T10:00:00+08:00\n"
+            "first commit\n"
+            "tree789sha"
+        )
+
+        result = get_commit_info(Path("/tmp/repo"))
+
+        assert result == {
+            "commit": "abc123def456",
+            "author_name": "John Doe",
+            "author_email": "john@example.com",
+            "author_date": "2026-01-15T10:00:00+08:00",
+            "subject": "first commit",
+            "tree_sha": "tree789sha",
+        }
+        mock_git.assert_called_once_with(
+            "log", "-1", "--format=%H%n%an%n%ae%n%aI%n%s%n%T", cwd=Path("/tmp/repo")
+        )
+
+
+class TestCountCommits:
+    """Test count_commits() function."""
+
+    @patch("verify_bsp_repos.git")
+    def test_returns_commit_count(self, mock_git: Any) -> None:
+        """Test parsing rev-list count output."""
+        mock_git.return_value = "1"
+
+        result = count_commits(Path("/tmp/repo"))
+
+        assert result == 1
+        mock_git.assert_called_once_with("rev-list", "--count", "HEAD", cwd=Path("/tmp/repo"))
+
+    @patch("verify_bsp_repos.git")
+    def test_returns_multiple_commits(self, mock_git: Any) -> None:
+        """Test with multiple commits."""
+        mock_git.return_value = "42"
+
+        result = count_commits(Path("/tmp/repo"))
+
+        assert result == 42
+
+
+class TestListFiles:
+    """Test list_files() function."""
+
+    @patch("verify_bsp_repos.git")
+    def test_parses_file_list(self, mock_git: Any) -> None:
+        """Test parsing ls-tree output into file list."""
+        mock_git.return_value = "file1.c\nfile2.h\ndir/file3.txt"
+
+        result = list_files(Path("/tmp/repo"))
+
+        assert result == ["file1.c", "file2.h", "dir/file3.txt"]
+        mock_git.assert_called_once_with(
+            "ls-tree", "-r", "--name-only", "HEAD", cwd=Path("/tmp/repo")
+        )
+
+    @patch("verify_bsp_repos.git")
+    def test_returns_empty_for_empty_output(self, mock_git: Any) -> None:
+        """Test that empty output returns empty list."""
+        mock_git.return_value = ""
+
+        result = list_files(Path("/tmp/repo"))
+
+        assert result == []
+
+
+class TestCloneShallow:
+    """Test clone_shallow() function."""
+
+    @patch("verify_bsp_repos.git")
+    def test_clone_flags(self, mock_git: Any) -> None:
+        """Test that clone_shallow passes correct flags."""
+        dest = Path("/tmp/dest")
+
+        clone_shallow("https://github.com/test/repo.git", dest)
+
+        mock_git.assert_called_once_with(
+            "clone",
+            "--depth=1",
+            "--no-checkout",
+            "--filter=blob:none",
+            "https://github.com/test/repo.git",
+            str(dest),
+        )
+
+
+class TestVerifyRepo:
+    """Test verify_repo() function."""
+
+    @patch("verify_bsp_repos.count_commits")
+    @patch("verify_bsp_repos.list_files")
+    @patch("verify_bsp_repos.get_commit_info")
+    @patch("verify_bsp_repos.clone_shallow")
+    def test_returns_info_files_count(
+        self,
+        mock_clone: Any,
+        mock_info: Any,
+        mock_files: Any,
+        mock_count: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Test verify_repo returns (info, files, count) tuple."""
+        mock_info.return_value = {
+            "commit": "abc123",
+            "author_name": "Test",
+            "author_email": "test@example.com",
+            "author_date": "2026-01-01T00:00:00Z",
+            "subject": "first commit",
+            "tree_sha": "tree123",
+        }
+        mock_files.return_value = ["file1.c", "file2.h"]
+        mock_count.return_value = 1
+
+        info, files, count = verify_repo("https://github.com/test/repo.git", str(tmp_path))
+
+        assert info["commit"] == "abc123"
+        assert files == ["file1.c", "file2.h"]
+        assert count == 1
+        mock_clone.assert_called_once()
+
+    @patch("verify_bsp_repos.count_commits")
+    @patch("verify_bsp_repos.list_files")
+    @patch("verify_bsp_repos.get_commit_info")
+    @patch("verify_bsp_repos.clone_shallow")
+    def test_repo_name_from_url(
+        self,
+        mock_clone: Any,
+        mock_info: Any,
+        mock_files: Any,
+        mock_count: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Test that repo name is derived from URL."""
+        mock_info.return_value = {
+            "commit": "abc",
+            "author_name": "Test",
+            "author_email": "t@e.com",
+            "author_date": "2026-01-01",
+            "subject": "test",
+            "tree_sha": "tree",
+        }
+        mock_files.return_value = []
+        mock_count.return_value = 1
+
+        verify_repo("https://github.com/gl-inet/kernel-4.19.git", str(tmp_path))
+
+        # clone_shallow should be called with dest = tmpdir / "kernel-4.19"
+        clone_dest = mock_clone.call_args[0][1]
+        assert clone_dest == tmp_path / "kernel-4.19"
+
+
+class TestBuildToml:
+    """Test build_toml() end-to-end function."""
+
+    @patch("verify_bsp_repos.verify_repo")
+    def test_produces_valid_toml(self, mock_verify: Any) -> None:
+        """Test that build_toml produces valid TOML."""
+        # Mock both kernel and buildroot verify_repo calls
+        kernel_info = {
+            "commit": "fc316e95",
+            "author_name": "xiaojiang2017",
+            "author_email": "xj@example.com",
+            "author_date": "2026-01-15T10:00:00+08:00",
+            "subject": "first commit",
+            "tree_sha": "ktree123",
+        }
+        kernel_files = [
+            "arch/arm/configs/rv1126_defconfig",
+            "arch/arm/configs/rv1126_robot_defconfig",
+            "Makefile",
+        ]
+
+        buildroot_info = {
+            "commit": "4a4f065a",
+            "author_name": "xiaojiang2017",
+            "author_email": "xj@example.com",
+            "author_date": "2026-01-15T10:00:00+08:00",
+            "subject": "first commit",
+            "tree_sha": "btree456",
+        }
+        buildroot_files = [
+            "configs/rockchip_rv1126_defconfig",
+            "Makefile",
+        ]
+
+        mock_verify.side_effect = [
+            (kernel_info, kernel_files, 1),
+            (buildroot_info, buildroot_files, 1),
+        ]
+
+        result = build_toml()
+
+        # Should be valid TOML
+        parsed = tomlkit.loads(result)
+        assert parsed["kernel_head_commit"] == "fc316e95"
+        assert parsed["kernel_is_squashed_import"] is True
+        assert parsed["kernel_rm1_dts_found"] is False
+        assert parsed["kernel_rm1_dts_files"] == []
+        assert parsed["kernel_rm1_defconfig_found"] is False
+        assert parsed["kernel_glinet_files_found"] is False
+        assert parsed["kernel_total_files"] == 3
+
+        assert parsed["buildroot_head_commit"] == "4a4f065a"
+        assert parsed["buildroot_is_squashed_import"] is True
+        assert parsed["buildroot_rm1_defconfig_found"] is False
+        assert parsed["buildroot_glinet_files_found"] is False
+        assert parsed["buildroot_total_files"] == 2
+
+    @patch("verify_bsp_repos.verify_repo")
+    def test_detects_rm1_files(self, mock_verify: Any) -> None:
+        """Test that build_toml detects RM1-specific files when present."""
+        kernel_info = {
+            "commit": "abc123",
+            "author_name": "Test",
+            "author_email": "t@e.com",
+            "author_date": "2026-01-01",
+            "subject": "test",
+            "tree_sha": "tree",
+        }
+        kernel_files = [
+            "arch/arm/boot/dts/rv1126-rm1.dts",
+            "arch/arm/configs/rv1126_rm1_defconfig",
+            "arch/arm/configs/rv1126_defconfig",
+        ]
+
+        buildroot_info = dict(kernel_info)
+        buildroot_info["commit"] = "def456"
+        buildroot_files = [
+            "configs/rockchip_rv1126_rm1_defconfig",
+        ]
+
+        mock_verify.side_effect = [
+            (kernel_info, kernel_files, 1),
+            (buildroot_info, buildroot_files, 1),
+        ]
+
+        result = build_toml()
+        parsed = tomlkit.loads(result)
+
+        assert parsed["kernel_rm1_dts_found"] is True
+        assert "rv1126-rm1.dts" in parsed["kernel_rm1_dts_files"][0]
+        assert parsed["kernel_rm1_defconfig_found"] is True
+        assert parsed["buildroot_rm1_defconfig_found"] is True
+
+    @patch("verify_bsp_repos.verify_repo")
+    def test_not_squashed_when_multiple_commits(self, mock_verify: Any) -> None:
+        """Test that is_squashed_import is False when commit_count > 1."""
+        info = {
+            "commit": "abc",
+            "author_name": "Test",
+            "author_email": "t@e.com",
+            "author_date": "2026-01-01",
+            "subject": "test",
+            "tree_sha": "tree",
+        }
+
+        mock_verify.side_effect = [
+            (info, [], 5),
+            (info, [], 3),
+        ]
+
+        result = build_toml()
+        parsed = tomlkit.loads(result)
+
+        assert parsed["kernel_is_squashed_import"] is False
+        assert parsed["buildroot_is_squashed_import"] is False
+
+
+class TestMain:
+    """Test main() entry point."""
+
+    @patch("verify_bsp_repos.build_toml")
+    @patch("sys.argv", ["verify_bsp_repos.py"])
+    def test_default_prints_to_stdout(
+        self, mock_build: Any, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that main() prints TOML to stdout by default."""
+        mock_build.return_value = 'kernel_head_commit = "abc123"\n'
+
+        main()
+
+        captured = capsys.readouterr()
+        assert 'kernel_head_commit = "abc123"' in captured.out
+
+    @patch("verify_bsp_repos.build_toml")
+    @patch("sys.argv", ["verify_bsp_repos.py", "--write"])
+    def test_write_flag_creates_file(
+        self, mock_build: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that --write flag writes to results/bsp_repos.toml."""
+        mock_build.return_value = 'kernel_head_commit = "abc123"\n'
+
+        monkeypatch.chdir(tmp_path)
+        main()
+
+        out_path = tmp_path / "results" / "bsp_repos.toml"
+        assert out_path.exists()
+        assert 'kernel_head_commit = "abc123"' in out_path.read_text()

--- a/tests/test_verify_bsp_repos.py
+++ b/tests/test_verify_bsp_repos.py
@@ -15,6 +15,8 @@ import tomlkit
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from verify_bsp_repos import (
+    BUILDROOT_KNOWN_TREE_SHA,
+    KERNEL_KNOWN_TREE_SHA,
     build_toml,
     clone_shallow,
     count_commits,
@@ -411,12 +413,14 @@ class TestBuildToml:
         assert parsed["kernel_rm1_dts_files"] == []
         assert parsed["kernel_rm1_defconfig_found"] is False
         assert parsed["kernel_glinet_files_found"] is False
+        assert parsed["kernel_tree_sha_unchanged"] is False  # test SHA != known SHA
         assert parsed["kernel_total_files"] == 3
 
         assert parsed["buildroot_head_commit"] == "4a4f065a"
         assert parsed["buildroot_is_squashed_import"] is True
         assert parsed["buildroot_rm1_defconfig_found"] is False
         assert parsed["buildroot_glinet_files_found"] is False
+        assert parsed["buildroot_tree_sha_unchanged"] is False  # test SHA != known SHA
         assert parsed["buildroot_total_files"] == 2
 
     @patch("verify_bsp_repos.verify_repo")
@@ -454,6 +458,37 @@ class TestBuildToml:
         assert "rv1126-rm1.dts" in parsed["kernel_rm1_dts_files"][0]
         assert parsed["kernel_rm1_defconfig_found"] is True
         assert parsed["buildroot_rm1_defconfig_found"] is True
+
+    @patch("verify_bsp_repos.verify_repo")
+    def test_tree_sha_unchanged_when_matching(self, mock_verify: Any) -> None:
+        """Test that tree_sha_unchanged is True when tree SHA matches known value."""
+        kernel_info = {
+            "commit": "fc316e95",
+            "author_name": "xiaojiang2017",
+            "author_email": "xj@example.com",
+            "author_date": "2026-01-15T10:00:00+08:00",
+            "subject": "first commit",
+            "tree_sha": KERNEL_KNOWN_TREE_SHA,
+        }
+        buildroot_info = {
+            "commit": "4a4f065a",
+            "author_name": "xiaojiang2017",
+            "author_email": "xj@example.com",
+            "author_date": "2026-01-15T10:00:00+08:00",
+            "subject": "first commit",
+            "tree_sha": BUILDROOT_KNOWN_TREE_SHA,
+        }
+
+        mock_verify.side_effect = [
+            (kernel_info, [], 1),
+            (buildroot_info, [], 1),
+        ]
+
+        result = build_toml()
+        parsed = tomlkit.loads(result)
+
+        assert parsed["kernel_tree_sha_unchanged"] is True
+        assert parsed["buildroot_tree_sha_unchanged"] is True
 
     @patch("verify_bsp_repos.verify_repo")
     def test_not_squashed_when_multiple_commits(self, mock_verify: Any) -> None:


### PR DESCRIPTION
## Summary

- Update README.md and GPL-COMPLIANCE-ANALYSIS.md to reflect GL.iNet's January 2026 publication of kernel-4.19 and buildroot-2018 repositories
- Shift narrative from "has not released" to "published but incomplete" — both repos contain only unmodified Rockchip BSP code without RM1-specific modifications
- Add Notes column to README compliance table with per-component BSP status
- Add three-tier status in GPL analysis (Not Released / Base BSP Only / Released)
- Expand "What Has Been Released" section with detailed gap documentation
- Add BSP repository verification script and TOML results (review-driven scope expansion)
- Add 32 unit tests for verify_bsp_repos.py; fix datetime.UTC bug discovered during testing

## Issue

Closes #122

## Implementation plan

<details>
<summary>Plan</summary>

# BSP Compliance Status Update Implementation Plan

**Goal:** Update README.md and GPL-COMPLIANCE-ANALYSIS.md to reflect GL.iNet's January 2026 publication of Rockchip BSP repositories, documenting that source was published but remains incomplete for GPL compliance.

**Architecture:** Pure documentation edits to two markdown files. No code, no scripts, no tests. Each task edits one file with precise string replacements.

**Acceptance Criteria — what must be TRUE when this plan is done:**
- [x] README.md PROJECT PAUSED banner references the published repos and their gaps
- [x] README.md intro paragraph says "published but incomplete" instead of "has not released"
- [x] README.md compliance table has a Notes column with per-component BSP status
- [x] README.md forum reference updated to March 2026
- [x] GPL-COMPLIANCE-ANALYSIS.md opening statement says "complete" qualifier and mentions Jan 2026 publications
- [x] GPL-COMPLIANCE-ANALYSIS.md status table has three tiers (Not Released / Base BSP Only / Released)
- [x] GPL-COMPLIANCE-ANALYSIS.md "What Has Been Released" section includes kernel-4.19 and buildroot-2018 entries
- [x] GPL-COMPLIANCE-ANALYSIS.md per-component source code status lines updated for 8 BSP components
- [x] GPL-COMPLIANCE-ANALYSIS.md revision history has v0.4 entry
- [x] GPL-COMPLIANCE-ANALYSIS.md references section includes new repo links

**Task 1: Update README.md** [Independent] — 5 edits: PROJECT PAUSED banner, intro paragraph, findings summary, compliance table (add Notes column), forum reference date.

**Task 2: Update GPL-COMPLIANCE-ANALYSIS.md** [Independent] — 13 edits: opening statement, status table (three tiers), 7 source code status lines, build system analysis, "What Has Been Released" expansion, references, revision history.

Full plan: `docs/plans/2026-03-02-bsp-compliance-status-update-plan.md`

</details>

## Scope expansion during review

The initial PR was documentation-only. During code review, the following were added:
- `scripts/verify_bsp_repos.py` — BSP repository verification script (shallow-clone repos, check for RM1 artifacts)
- `results/bsp_repos.toml` — verification results consumed by documentation citations
- `tests/test_verify_bsp_repos.py` — 32 unit tests covering all script functions
- `fix:` commits correcting verification claims and a datetime.UTC bug

## Post-review fixes

Addressed code review findings as atomic commits:

| Commit | Finding | Resolution |
|--------|---------|------------|
| `259c415` | Citation comments outside table cell delimiters | Moved `<!-- cite: -->` inside table cells |
| `c5f3969` | Hardcoded BSP commit hashes unverifiable | Added tree SHA change-detection constants and provenance comments; confirmed Rockchip BSP commits are from private SDK (not publicly reachable) |
| `4c84f62` | Fragile URL parsing in `verify_repo` | Extracted `repo_name_from_url()` using `urllib.parse` + `PurePosixPath.stem`; added 4 edge-case tests |
| `b4a89bf` | Terse glibc version mismatch note | Clarified to "Version mismatch: BSP ships 2.29, firmware uses 2.28 (external toolchain)" |

Follow-up issues created for lower-priority findings:
- #124 — Simplify `add_repo_section` signature with dataclasses
- #125 — Replace `sys.path` manipulation with `conftest.py` in tests
- #126 — Make `verify_bsp_repos.py` output deterministic

## Checklist

- [x] Linked to a GitHub issue
- [x] Implementation plan included above
- [x] `pytest` passes (876 tests, linting, formatting, shellcheck, coverage)
- [x] Conventional commit messages used (`docs:`, `fix:`, `feat:`, `refactor:`)
- [x] No binary files or proprietary data committed
- [x] New analysis results include `_source` and `_method` metadata (via TOML comments in bsp_repos.toml)
- [x] `/verification-before-completion` — all 10 acceptance criteria verified with evidence
- [x] `/requesting-code-review` — spec compliance review + code quality review passed
- [x] Code review findings addressed (4 commits) or tracked as issues (3 issues)
- [x] Documentation updated

## Skills used

- [x] `/brainstorming`
- [x] `/writing-plans`
- [ ] `/executing-plans`
- [x] `/verification-before-completion` (auto-triggered)
- [x] `/requesting-code-review`
- [x] `/finishing-a-development-branch` (auto-triggered)
- [ ] `/using-git-worktrees`
- [ ] `/systematic-debugging`
- [ ] `/writing-skills` (for skill contributions)
- [ ] `/writing-clearly-and-concisely`

### Process notes

Used `/subagent-driven-development` instead of `/executing-plans` — both tasks ran in parallel with two-stage review (spec + code quality). Branch and issue were created retroactively after implementation (see audit in conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)