### PR TITLE
fix: Simplify .claude/ gitignore to wildcard + agent whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,35 +47,12 @@ htmlcov/
 *.cover
 .hypothesis/
 
-# Claude Code - local settings and personal tooling
-.claude/settings.local.json
-.claude/bin/
-.claude/var/
-.claude/lib/
-.claude/hooks/
-.claude/etc/
-.claude/commands/
-.claude/scripts/
-.claude/work/
-
-# Claude Code skills - whitelist tracked skills
-.claude/skills/*
-!.claude/skills/UPSTREAM-superpowers.md
-!.claude/skills/brainstorming/
-!.claude/skills/code-simplification/
-!.claude/skills/dispatching-parallel-agents/
-!.claude/skills/executing-plans/
-!.claude/skills/finishing-a-development-branch/
-!.claude/skills/receiving-code-review/
-!.claude/skills/requesting-code-review/
-!.claude/skills/subagent-driven-development/
-!.claude/skills/systematic-debugging/
-!.claude/skills/test-driven-development/
-!.claude/skills/using-git-worktrees/
-!.claude/skills/verification-before-completion/
-!.claude/skills/writing-clearly-and-concisely/
-!.claude/skills/writing-plans/
-!.claude/skills/writing-skills/
+# Claude Code - ignore everything except project-specific agents
+.claude/*
+!.claude/agents/
+.claude/agents/*
+!.claude/agents/code-reviewer.md
+!.claude/agents/quick-task.md
 
 # Plans - local working directory, not committed (see CONTRIBUTING.md)
 docs/plans/


### PR DESCRIPTION
## Summary

- Replace 28 lines of individual `.claude/` ignore rules and stale skills whitelist with a compact wildcard pattern
- Whitelist only the two tracked agents by name (`code-reviewer.md`, `quick-task.md`)
- Prevents future local plugin files from being accidentally tracked

Follows up on PR #132 / issue #131 — the 5 untracked skill directories left on disk have been deleted locally.

Closes #133

## Test plan

- [x] `uv run pytest` — 873 passed
- [x] `git ls-files .claude/` — only agents tracked
- [x] Pre-push hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)